### PR TITLE
Show payment hash on rebalance pages with link to route

### DIFF
--- a/gui/templates/channel.html
+++ b/gui/templates/channel.html
@@ -243,6 +243,7 @@
       <th>Fees Paid</th>
       <th>Last Hop Alias</th>
       <th>Status</th>
+      <th>Hash</th>
     </tr>
     {% for rebalance in rebalances %}
     <tr>
@@ -255,8 +256,9 @@
       <td>{{ rebalance.fee_limit|intcomma }}</td>
       <td>{{ rebalance.ppm|intcomma }}</td>
       <td>{% if rebalance.status == 2 %}{{ rebalance.fees_paid|intcomma }}{% else %}---{% endif %}</td>
-      <td>{% if rebalance.target_alias == '' %}None Specified{% else %}{{ rebalance.target_alias }}{% endif %}</td>
+      <td>{% if rebalance.target_alias == '' %}---{% else %}{{ rebalance.target_alias }}{% endif %}</td>
       <td title="{{ rebalance.status }}">{% if rebalance.status == 0 %}Pending{% elif rebalance.status == 1 %}In-Flight{% elif rebalance.status == 2 %}<a href="/route?={{ rebalance.payment_hash }}" target="_blank">Successful</a>{% elif rebalance.status == 3 %}Timeout{% elif rebalance.status == 4 %}No Route{% elif rebalance.status == 5 %}Error{% elif rebalance.status == 6 %}Incorrect Payment Details{% elif rebalance.status == 7 %}Insufficient Balance{% elif rebalance.status == 400 %}Rebalancer Request Failed{% elif rebalance.status == 408 %}Rebalancer Request Timeout{% else %}{{ rebalance.status }}{% endif %}</td>
+      <td>{% if rebalance.payment_hash == '' %}---{% else %}<a href="/route?={{ rebalance.payment_hash }}" target="_blank">{{ rebalance.payment_hash }}</a>{% endif %}</td>
     </tr>
     {% endfor %}
   </table>

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -459,20 +459,22 @@
       <th>Fees Paid</th>
       <th>Last Hop Alias</th>
       <th>Status</th>
+      <th>Hash</th>
     </tr>
     {% for rebalance in rebalances %}
     <tr>
       <td title="{{ rebalance.requested }}">{{ rebalance.requested|naturaltime }}</td>
-      <td title="{{ rebalance.start }}">{% if rebalance.status == 0 %}---{% else %}{{ rebalance.start|naturaltime }}{% endif %}</td>
-      <td title="{{ rebalance.stop }}">{% if rebalance.status > 1 %}{{ rebalance.stop|naturaltime }}{% else %}---{% endif %}</td>
+      <td {% if rebalance.status == 0 %}>---{% else %}title="{{ rebalance.start }}">{{ rebalance.start|naturaltime }}{% endif %}</td>
+      <td {% if rebalance.status > 1 %}title="{{ rebalance.stop }}">{{ rebalance.stop|naturaltime }}{% else %}>---{% endif %}</td>
       <td>{{ rebalance.duration }} minutes</td>
       <td>{% if rebalance.status == 2 %}{{ rebalance.stop|timeuntil:rebalance.start }}{% else %}---{% endif %}</td>
       <td>{{ rebalance.value|intcomma }}</td>
       <td>{{ rebalance.fee_limit|intcomma }}</td>
       <td>{{ rebalance.ppm|intcomma }}</td>
-      <td>{% if rebalance.status == 2 %}{{ rebalance.fees_paid|intcomma}}{% else %}---{% endif %}</td>
-      <td>{% if rebalance.target_alias == '' %}None Specified{% else %}{{ rebalance.target_alias }}{% endif %}</td>
+      <td>{% if rebalance.status == 2 %}{{ rebalance.fees_paid|intcomma }}{% else %}---{% endif %}</td>
+      <td>{% if rebalance.target_alias == '' %}---{% else %}{{ rebalance.target_alias }}{% endif %}</td>
       <td title="{{ rebalance.status }}">{% if rebalance.status == 0 %}Pending{% elif rebalance.status == 1 %}In-Flight{% elif rebalance.status == 2 %}<a href="/route?={{ rebalance.payment_hash }}" target="_blank">Successful</a>{% elif rebalance.status == 3 %}Timeout{% elif rebalance.status == 4 %}No Route{% elif rebalance.status == 5 %}Error{% elif rebalance.status == 6 %}Incorrect Payment Details{% elif rebalance.status == 7 %}Insufficient Balance{% elif rebalance.status == 400 %}Rebalancer Request Failed{% elif rebalance.status == 408 %}Rebalancer Request Timeout{% else %}{{ rebalance.status }}{% endif %}</td>
+      <td>{% if rebalance.payment_hash == '' %}---{% else %}<a href="/route?={{ rebalance.payment_hash }}" target="_blank">{{ rebalance.payment_hash }}</a>{% endif %}</td>
     </tr>
     {% endfor %}
   </table>

--- a/gui/templates/rebalances.html
+++ b/gui/templates/rebalances.html
@@ -4,6 +4,43 @@
 {% load humanize %}
 {% if rebalances %}
 <div class="w3-container w3-padding-small">
+  <h2>Last Successful Rebalances</h2>
+  <table class="w3-table-all w3-centered w3-hoverable">
+    <tr>
+      <th>Requested</th>
+      <th>Start</th>
+      <th>Stop</th>
+      <th>Scheduled Duration</th>
+      <th>Actual Duration</th>
+      <th>Value</th>
+      <th>Fee Limit</th>
+      <th>Target PPM</th>
+      <th>Fees Paid</th>
+      <th>Last Hop Alias</th>
+      <th>Status</th>
+      <th>Hash</th>
+    </tr>
+    {% for rebalance in rebalances %}
+        {% if rebalance.status == 2 %}
+          <tr>
+            <td title="{{ rebalance.requested }}">{{ rebalance.requested|naturaltime }}</td>
+            <td {% if rebalance.status == 0 %}>---{% else %}title="{{ rebalance.start }}">{{ rebalance.start|naturaltime }}{% endif %}</td>
+            <td {% if rebalance.status > 1 %}title="{{ rebalance.stop }}">{{ rebalance.stop|naturaltime }}{% else %}>---{% endif %}</td>
+            <td>{{ rebalance.duration }} minutes</td>
+            <td>{% if rebalance.status == 2 %}{{ rebalance.stop|timeuntil:rebalance.start }}{% else %}---{% endif %}</td>
+            <td>{{ rebalance.value|intcomma }}</td>
+            <td>{{ rebalance.fee_limit|intcomma }}</td>
+            <td>{{ rebalance.ppm|intcomma }}</td>
+            <td>{% if rebalance.status == 2 %}{{ rebalance.fees_paid|intcomma }}{% else %}---{% endif %}</td>
+            <td>{% if rebalance.target_alias == '' %}---{% else %}{{ rebalance.target_alias }}{% endif %}</td>
+            <td title="{{ rebalance.status }}">{% if rebalance.status == 0 %}Pending{% elif rebalance.status == 1 %}In-Flight{% elif rebalance.status == 2 %}<a href="/route?={{ rebalance.payment_hash }}" target="_blank">Successful</a>{% elif rebalance.status == 3 %}Timeout{% elif rebalance.status == 4 %}No Route{% elif rebalance.status == 5 %}Error{% elif rebalance.status == 6 %}Incorrect Payment Details{% elif rebalance.status == 7 %}Insufficient Balance{% elif rebalance.status == 400 %}Rebalancer Request Failed{% elif rebalance.status == 408 %}Rebalancer Request Timeout{% else %}{{ rebalance.status }}{% endif %}</td>
+            <td>{% if rebalance.payment_hash == '' %}---{% else %}<a href="/route?={{ rebalance.payment_hash }}" target="_blank">{{ rebalance.payment_hash }}</a>{% endif %}</td>
+          </tr>
+        {% endif %}
+    {% endfor %}
+  </table>
+</div>
+<div class="w3-container w3-padding-small">
   <h2>Last 150 Rebalances</h2>
   <table class="w3-table-all w3-centered w3-hoverable">
     <tr>
@@ -18,6 +55,7 @@
       <th>Fees Paid</th>
       <th>Last Hop Alias</th>
       <th>Status</th>
+      <th>Hash</th>
     </tr>
     {% for rebalance in rebalances %}
     <tr>
@@ -30,8 +68,9 @@
       <td>{{ rebalance.fee_limit|intcomma }}</td>
       <td>{{ rebalance.ppm|intcomma }}</td>
       <td>{% if rebalance.status == 2 %}{{ rebalance.fees_paid|intcomma }}{% else %}---{% endif %}</td>
-      <td>{% if rebalance.target_alias == '' %}None Specified{% else %}{{ rebalance.target_alias }}{% endif %}</td>
+      <td>{% if rebalance.target_alias == '' %}---{% else %}{{ rebalance.target_alias }}{% endif %}</td>
       <td title="{{ rebalance.status }}">{% if rebalance.status == 0 %}Pending{% elif rebalance.status == 1 %}In-Flight{% elif rebalance.status == 2 %}<a href="/route?={{ rebalance.payment_hash }}" target="_blank">Successful</a>{% elif rebalance.status == 3 %}Timeout{% elif rebalance.status == 4 %}No Route{% elif rebalance.status == 5 %}Error{% elif rebalance.status == 6 %}Incorrect Payment Details{% elif rebalance.status == 7 %}Insufficient Balance{% elif rebalance.status == 400 %}Rebalancer Request Failed{% elif rebalance.status == 408 %}Rebalancer Request Timeout{% else %}{{ rebalance.status }}{% endif %}</td>
+      <td>{% if rebalance.payment_hash == '' %}---{% else %}<a href="/route?={{ rebalance.payment_hash }}" target="_blank">{{ rebalance.payment_hash }}</a>{% endif %}</td>
     </tr>
     {% endfor %}
   </table>

--- a/gui/templates/rebalances.html
+++ b/gui/templates/rebalances.html
@@ -2,7 +2,7 @@
 {% block title %} {{ block.super }} - Rebalances{% endblock %}
 {% block content %}
 {% load humanize %}
-{% if rebalances %}
+{% if rebalances_success %}
 <div class="w3-container w3-padding-small">
   <h2>Last Successful Rebalances</h2>
   <table class="w3-table-all w3-centered w3-hoverable">
@@ -20,26 +20,26 @@
       <th>Status</th>
       <th>Hash</th>
     </tr>
-    {% for rebalance in rebalances %}
-        {% if rebalance.status == 2 %}
-          <tr>
-            <td title="{{ rebalance.requested }}">{{ rebalance.requested|naturaltime }}</td>
-            <td {% if rebalance.status == 0 %}>---{% else %}title="{{ rebalance.start }}">{{ rebalance.start|naturaltime }}{% endif %}</td>
-            <td {% if rebalance.status > 1 %}title="{{ rebalance.stop }}">{{ rebalance.stop|naturaltime }}{% else %}>---{% endif %}</td>
-            <td>{{ rebalance.duration }} minutes</td>
-            <td>{% if rebalance.status == 2 %}{{ rebalance.stop|timeuntil:rebalance.start }}{% else %}---{% endif %}</td>
-            <td>{{ rebalance.value|intcomma }}</td>
-            <td>{{ rebalance.fee_limit|intcomma }}</td>
-            <td>{{ rebalance.ppm|intcomma }}</td>
-            <td>{% if rebalance.status == 2 %}{{ rebalance.fees_paid|intcomma }}{% else %}---{% endif %}</td>
-            <td>{% if rebalance.target_alias == '' %}---{% else %}{{ rebalance.target_alias }}{% endif %}</td>
-            <td title="{{ rebalance.status }}">{% if rebalance.status == 0 %}Pending{% elif rebalance.status == 1 %}In-Flight{% elif rebalance.status == 2 %}<a href="/route?={{ rebalance.payment_hash }}" target="_blank">Successful</a>{% elif rebalance.status == 3 %}Timeout{% elif rebalance.status == 4 %}No Route{% elif rebalance.status == 5 %}Error{% elif rebalance.status == 6 %}Incorrect Payment Details{% elif rebalance.status == 7 %}Insufficient Balance{% elif rebalance.status == 400 %}Rebalancer Request Failed{% elif rebalance.status == 408 %}Rebalancer Request Timeout{% else %}{{ rebalance.status }}{% endif %}</td>
-            <td>{% if rebalance.payment_hash == '' %}---{% else %}<a href="/route?={{ rebalance.payment_hash }}" target="_blank">{{ rebalance.payment_hash }}</a>{% endif %}</td>
-          </tr>
-        {% endif %}
+    {% for rebalance in rebalances_success %}
+      <tr>
+        <td title="{{ rebalance.requested }}">{{ rebalance.requested|naturaltime }}</td>
+        <td {% if rebalance.status == 0 %}>---{% else %}title="{{ rebalance.start }}">{{ rebalance.start|naturaltime }}{% endif %}</td>
+        <td {% if rebalance.status > 1 %}title="{{ rebalance.stop }}">{{ rebalance.stop|naturaltime }}{% else %}>---{% endif %}</td>
+        <td>{{ rebalance.duration }} minutes</td>
+        <td>{% if rebalance.status == 2 %}{{ rebalance.stop|timeuntil:rebalance.start }}{% else %}---{% endif %}</td>
+        <td>{{ rebalance.value|intcomma }}</td>
+        <td>{{ rebalance.fee_limit|intcomma }}</td>
+        <td>{{ rebalance.ppm|intcomma }}</td>
+        <td>{% if rebalance.status == 2 %}{{ rebalance.fees_paid|intcomma }}{% else %}---{% endif %}</td>
+        <td>{% if rebalance.target_alias == '' %}---{% else %}{{ rebalance.target_alias }}{% endif %}</td>
+        <td title="{{ rebalance.status }}">{% if rebalance.status == 0 %}Pending{% elif rebalance.status == 1 %}In-Flight{% elif rebalance.status == 2 %}<a href="/route?={{ rebalance.payment_hash }}" target="_blank">Successful</a>{% elif rebalance.status == 3 %}Timeout{% elif rebalance.status == 4 %}No Route{% elif rebalance.status == 5 %}Error{% elif rebalance.status == 6 %}Incorrect Payment Details{% elif rebalance.status == 7 %}Insufficient Balance{% elif rebalance.status == 400 %}Rebalancer Request Failed{% elif rebalance.status == 408 %}Rebalancer Request Timeout{% else %}{{ rebalance.status }}{% endif %}</td>
+        <td>{% if rebalance.payment_hash == '' %}---{% else %}<a href="/route?={{ rebalance.payment_hash }}" target="_blank">{{ rebalance.payment_hash }}</a>{% endif %}</td>
+      </tr>
     {% endfor %}
   </table>
 </div>
+{% endif %}
+{% if rebalances %}
 <div class="w3-container w3-padding-small">
   <h2>Last 150 Rebalances</h2>
   <table class="w3-table-all w3-centered w3-hoverable">

--- a/gui/templates/rebalancing.html
+++ b/gui/templates/rebalancing.html
@@ -108,6 +108,7 @@
       <th>Fees Paid</th>
       <th>Last Hop Alias</th>
       <th>Status</th>
+      <th>Hash</th>
     </tr>
     {% for rebalance in rebalancer %}
     <tr>
@@ -120,8 +121,9 @@
       <td>{{ rebalance.fee_limit|intcomma }}</td>
       <td>{{ rebalance.ppm|intcomma }}</td>
       <td>{% if rebalance.status == 2 %}{{ rebalance.fees_paid|intcomma }}{% else %}---{% endif %}</td>
-      <td>{% if rebalance.target_alias == '' %}None Specified{% else %}{{ rebalance.target_alias }}{% endif %}</td>
+      <td>{% if rebalance.target_alias == '' %}---{% else %}{{ rebalance.target_alias }}{% endif %}</td>
       <td title="{{ rebalance.status }}">{% if rebalance.status == 0 %}Pending{% elif rebalance.status == 1 %}In-Flight{% elif rebalance.status == 2 %}<a href="/route?={{ rebalance.payment_hash }}" target="_blank">Successful</a>{% elif rebalance.status == 3 %}Timeout{% elif rebalance.status == 4 %}No Route{% elif rebalance.status == 5 %}Error{% elif rebalance.status == 6 %}Incorrect Payment Details{% elif rebalance.status == 7 %}Insufficient Balance{% elif rebalance.status == 400 %}Rebalancer Request Failed{% elif rebalance.status == 408 %}Rebalancer Request Timeout{% else %}{{ rebalance.status }}{% endif %}</td>
+      <td>{% if rebalance.payment_hash == '' %}---{% else %}<a href="/route?={{ rebalance.payment_hash }}" target="_blank">{{ rebalance.payment_hash }}</a>{% endif %}</td>
     </tr>
     {% endfor %}
   </table>

--- a/gui/views.py
+++ b/gui/views.py
@@ -1469,10 +1469,20 @@ def invoices(request):
 @is_login_required(login_required(login_url='/lndg-admin/login/?next=/'), settings.LOGIN_REQUIRED)
 def rebalances(request):
     if request.method == 'GET':
-        context = {
-            'rebalances': Rebalancer.objects.all().annotate(ppm=Round((Sum('fee_limit')*1000000)/Sum('value'), output_field=IntegerField())).order_by('-id')[:150],
-        }
-        return render(request, 'rebalances.html', context)
+        try:
+            rebalances = Rebalancer.objects.all().annotate(ppm=Round((Sum('fee_limit')*1000000)/Sum('value'), output_field=IntegerField())).order_by('-id')
+            rebalances_success = rebalances.filter(status=2)
+            context = {
+                'rebalances': rebalances[:150],
+                'rebalances_success' : rebalances_success[:69]
+            }
+            return render(request, 'rebalances.html', context)
+        except Exception as e:
+            try:
+                error = str(e.code())
+            except:
+                error = str(e)
+            return render(request, 'error.html', {'error': error})
     else:
         return redirect('home')
 


### PR DESCRIPTION
Show payment hash on rebalance pages to take to route page.
Also show successful rebalances in a separate section. 