### PR TITLE
Remove Update Channel Policy from the Dashboard

### DIFF
--- a/gui/forms.py
+++ b/gui/forms.py
@@ -63,16 +63,6 @@ class RebalancerForm(forms.ModelForm):
     last_hop_pubkey = forms.CharField(label='funding_txid', max_length=66, required=False)
     duration = forms.IntegerField(label='duration')
 
-class ChanPolicyForm(forms.ModelForm):
-    class Meta:
-        model = Channels
-        fields = []
-    new_base_fee = forms.IntegerField(label='new_base_fee', required=False)
-    new_fee_rate = forms.IntegerField(label='new_fee_rate', required=False)
-    new_cltv = forms.IntegerField(label='new_cltv', required=False)
-    target_chans = ChanPolicyModelChoiceField(widget=forms.CheckboxSelectMultiple, queryset=Channels.objects.filter(is_open=1).order_by('-alias'), required=False)
-    target_all = forms.BooleanField(widget=forms.CheckboxSelectMultiple, required=False)
-
 class AutoRebalanceForm(forms.Form):
     chan_id = forms.IntegerField(label='chan_id', required=False)
     enabled = forms.IntegerField(label='enabled', required=False)

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -679,27 +679,4 @@
     </form>
   </div>
 </div>
-<div class="w3-container w3-padding-small">
-  <h2>Update Channel Policy</h2>
-  <div class="w3-container w3-padding-32">
-    <form action="/updatechanpolicy/" method="post">
-      {% csrf_token %}
-      <label for="new_base_fee">New Base Fee: </label>
-      <input id="new_base_fee" type="number" min="0" name="new_base_fee">
-      <label for="new_fee_rate">New Fee Rate: </label>
-      <input id="new_fee_rate" type="number" min="0" name="new_fee_rate">
-      <label for="new_cltv">New CLTV: </label>
-      <input id="new_cltv" type="number" min="18" name="new_cltv">
-      <label for="target_all">Target All Channels? </label>
-      <input id="target_all" type="checkbox" name="target_all">
-      <input type="submit" value="OK">
-      <ul class="w3-ul w3-border" style="width:35.2%">
-        <li><h3><label for="target_chans">Select Channels To Update: </label></h3></li>
-        {% for channel in chan_policy_form.target_chans %}
-          <li>{{ channel }}</li>
-        {% endfor %}
-      </ul>
-    </form>
-  </div>
-</div>
 {% endblock %}

--- a/gui/urls.py
+++ b/gui/urls.py
@@ -47,7 +47,6 @@ urlpatterns = [
     path('newaddress/', views.new_address_form, name='new-address-form'),
     path('createinvoice/', views.add_invoice_form, name='add-invoice-form'),
     path('rebalancer/', views.rebalance, name='rebalancer'),
-    path('updatechanpolicy/', views.update_chan_policy, name='updatechanpolicy'),
     path('autorebalance/', views.auto_rebalance, name='auto-rebalance'),
     path('update_channel/', views.update_channel, name='update-channel'),
     path('update_pending/', views.update_pending, name='update-pending'),

--- a/gui/views.py
+++ b/gui/views.py
@@ -8,7 +8,7 @@ from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
-from .forms import OpenChannelForm, CloseChannelForm, ConnectPeerForm, AddInvoiceForm, RebalancerForm, ChanPolicyForm, UpdateChannel, UpdateSetting, AutoRebalanceForm, AddTowerForm, RemoveTowerForm, DeleteTowerForm, BatchOpenForm, UpdatePending, UpdateClosing, UpdateKeysend, AddAvoid, RemoveAvoid
+from .forms import OpenChannelForm, CloseChannelForm, ConnectPeerForm, AddInvoiceForm, RebalancerForm, UpdateChannel, UpdateSetting, AutoRebalanceForm, AddTowerForm, RemoveTowerForm, DeleteTowerForm, BatchOpenForm, UpdatePending, UpdateClosing, UpdateKeysend, AddAvoid, RemoveAvoid
 from .models import Payments, PaymentHops, Invoices, Forwards, Channels, Rebalancer, LocalSettings, Peers, Onchain, Closures, Resolutions, PendingHTLCs, FailedHTLCs, Autopilot, Autofees, PendingChannels, AvoidNodes
 from .serializers import ConnectPeerSerializer, FailedHTLCSerializer, LocalSettingsSerializer, OpenChannelSerializer, CloseChannelSerializer, AddInvoiceSerializer, PaymentHopsSerializer, PaymentSerializer, InvoiceSerializer, ForwardSerializer, ChannelSerializer, PendingHTLCSerializer, RebalancerSerializer, UpdateAliasSerializer, PeerSerializer, OnchainSerializer, ClosuresSerializer, ResolutionsSerializer
 from gui.lnd_deps import lightning_pb2 as ln
@@ -300,7 +300,6 @@ def home(request):
                 'pending_force_closed': pending_force_closed,
                 'waiting_for_close': waiting_for_close,
                 'rebalances': rebalances[:12],
-                'chan_policy_form': ChanPolicyForm,
                 'local_settings': local_settings,
                 'pending_htlc_count': pending_htlc_count,
                 'failed_htlcs': FailedHTLCs.objects.all().order_by('-id')[:10],
@@ -1936,62 +1935,6 @@ def rebalance(request):
         else:
             messages.error(request, 'Invalid Request. Please try again.')
     return redirect(request.META.get('HTTP_REFERER'))
-
-@is_login_required(login_required(login_url='/lndg-admin/login/?next=/'), settings.LOGIN_REQUIRED)
-def update_chan_policy(request):
-    if request.method == 'POST':
-        form = ChanPolicyForm(request.POST)
-        if form.is_valid():
-            if form.cleaned_data['new_base_fee'] is not None or form.cleaned_data['new_fee_rate'] is not None or form.cleaned_data['new_cltv'] is not None:
-                try:
-                    stub = lnrpc.LightningStub(lnd_connect())
-                    if form.cleaned_data['target_all']:
-                        if form.cleaned_data['new_base_fee'] is not None and form.cleaned_data['new_fee_rate'] is not None and form.cleaned_data['new_cltv'] is not None:
-                            args = {'global': True, 'base_fee_msat': form.cleaned_data['new_base_fee'], 'fee_rate': (form.cleaned_data['new_fee_rate']/1000000), 'time_lock_delta': form.cleaned_data['new_cltv']}
-                            stub.UpdateChannelPolicy(ln.PolicyUpdateRequest(**args))
-                            channels = Channels.objects.filter(is_open=True)
-                            channels.update(local_base_fee=form.cleaned_data['new_base_fee'])
-                            channels.update(local_fee_rate=form.cleaned_data['new_fee_rate'])
-                            channels.update(local_cltv=form.cleaned_data['new_cltv'])
-                            channels.update(fees_updated=datetime.now())
-                        else:
-                            messages.error(request, 'You must specify all parameters when updating all channels.')
-                            return redirect('home')
-                    elif len(form.cleaned_data['target_chans']) > 0:
-                        for channel in form.cleaned_data['target_chans']:
-                            channel_point = ln.ChannelPoint()
-                            channel_point.funding_txid_bytes = bytes.fromhex(channel.funding_txid)
-                            channel_point.funding_txid_str = channel.funding_txid
-                            channel_point.output_index = channel.output_index
-                            new_base_fee = form.cleaned_data['new_base_fee'] if form.cleaned_data['new_base_fee'] is not None else channel.local_base_fee
-                            new_fee_rate = form.cleaned_data['new_fee_rate']/1000000 if form.cleaned_data['new_fee_rate'] is not None else channel.local_fee_rate/1000000
-                            new_cltv = form.cleaned_data['new_cltv'] if form.cleaned_data['new_cltv'] is not None else channel.local_cltv
-                            stub.UpdateChannelPolicy(ln.PolicyUpdateRequest(chan_point=channel_point, base_fee_msat=new_base_fee, fee_rate=new_fee_rate, time_lock_delta=new_cltv))
-                            db_channel = Channels.objects.get(chan_id=channel.chan_id)
-                            db_channel.local_base_fee = new_base_fee
-                            old_fee_rate = db_channel.local_fee_rate
-                            db_channel.local_fee_rate = new_fee_rate*1000000
-                            db_channel.local_cltv = new_cltv
-                            if form.cleaned_data['new_fee_rate'] is not None:
-                                db_channel.fees_updated = datetime.now()
-                                Autofees(chan_id=db_channel.chan_id, peer_alias=db_channel.alias, setting=(f"Manual"), old_value=old_fee_rate, new_value=db_channel.local_fee_rate).save()
-
-                            db_channel.save()
-                    else:
-                        messages.error(request, 'No channels were specified in the update request!')
-                        return redirect('home')
-                    messages.success(request, 'Channel policies updated! This will be broadcast during the next graph update!')
-                except Exception as e:
-                    error = str(e)
-                    details_index = error.find('details =') + 11
-                    debug_error_index = error.find('debug_error_string =') - 3
-                    error_msg = error[details_index:debug_error_index]
-                    messages.error(request, 'Error updating channel policies! Error: ' + error_msg)
-            else:
-                messages.error(request, 'You must specify at least one parameter.')
-        else:
-            messages.error(request, 'Invalid Request. Please try again.')
-    return redirect('home')
 
 @is_login_required(login_required(login_url='/lndg-admin/login/?next=/'), settings.LOGIN_REQUIRED)
 def auto_rebalance(request):

--- a/gui/views.py
+++ b/gui/views.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from .forms import OpenChannelForm, CloseChannelForm, ConnectPeerForm, AddInvoiceForm, RebalancerForm, UpdateChannel, UpdateSetting, AutoRebalanceForm, AddTowerForm, RemoveTowerForm, DeleteTowerForm, BatchOpenForm, UpdatePending, UpdateClosing, UpdateKeysend, AddAvoid, RemoveAvoid
-from .models import Payments, PaymentHops, Invoices, Forwards, Channels, Rebalancer, LocalSettings, Peers, Onchain, Closures, Resolutions, PendingHTLCs, FailedHTLCs, Autopilot, Autofees, PendingChannels, AvoidNodes
+from .models import Payments, PaymentHops, Invoices, Forwards, Channels, Rebalancer, LocalSettings, Peers, Onchain, Closures, Resolutions, PendingHTLCs, FailedHTLCs, Autopilot, Autofees, PendingChannels, AvoidNodes, PeerEvents
 from .serializers import ConnectPeerSerializer, FailedHTLCSerializer, LocalSettingsSerializer, OpenChannelSerializer, CloseChannelSerializer, AddInvoiceSerializer, PaymentHopsSerializer, PaymentSerializer, InvoiceSerializer, ForwardSerializer, ChannelSerializer, PendingHTLCSerializer, RebalancerSerializer, UpdateAliasSerializer, PeerSerializer, OnchainSerializer, ClosuresSerializer, ResolutionsSerializer
 from gui.lnd_deps import lightning_pb2 as ln
 from gui.lnd_deps import lightning_pb2_grpc as lnrpc

--- a/gui/views.py
+++ b/gui/views.py
@@ -8,7 +8,7 @@ from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
-from .forms import OpenChannelForm, CloseChannelForm, ConnectPeerForm, AddInvoiceForm, RebalancerForm, UpdateChannel, UpdateSetting, AutoRebalanceForm, AddTowerForm, RemoveTowerForm, DeleteTowerForm, BatchOpenForm, UpdatePending, UpdateClosing, UpdateKeysend, AddAvoid, RemoveAvoid
+from .forms import OpenChannelForm, CloseChannelForm, ConnectPeerForm, AddInvoiceForm, RebalancerForm, ChanPolicyForm, UpdateChannel, UpdateSetting, AutoRebalanceForm, AddTowerForm, RemoveTowerForm, DeleteTowerForm, BatchOpenForm, UpdatePending, UpdateClosing, UpdateKeysend, AddAvoid, RemoveAvoid
 from .models import Payments, PaymentHops, Invoices, Forwards, Channels, Rebalancer, LocalSettings, Peers, Onchain, Closures, Resolutions, PendingHTLCs, FailedHTLCs, Autopilot, Autofees, PendingChannels, AvoidNodes, PeerEvents
 from .serializers import ConnectPeerSerializer, FailedHTLCSerializer, LocalSettingsSerializer, OpenChannelSerializer, CloseChannelSerializer, AddInvoiceSerializer, PaymentHopsSerializer, PaymentSerializer, InvoiceSerializer, ForwardSerializer, ChannelSerializer, PendingHTLCSerializer, RebalancerSerializer, UpdateAliasSerializer, PeerSerializer, OnchainSerializer, ClosuresSerializer, ResolutionsSerializer
 from gui.lnd_deps import lightning_pb2 as ln


### PR DESCRIPTION
This PR removes the Update Channel Policy part from the Dashboard. Going to the Advanced Settings or Fee Rates page is much more convenient if anyone wants to change fees or CLTV for their channels.