### PR TITLE
Try failed rebalances until give up

### DIFF
--- a/rebalancer.py
+++ b/rebalancer.py
@@ -106,7 +106,8 @@ async def run_rebalancer(rebalance, worker):
                     print (f"{datetime.now()} RapidFire up {next_rebalance.target_alias=} {next_rebalance.value=} {rebalance.value=}")
                 else:
                     next_rebalance = None
-            elif rebalance.status > 2 and rebalance.duration <= 1 and rebalance.value > 69420:
+            # For failed rebalances, try in rapid fire with reduced balances until give up.
+            elif rebalance.status > 2 and rebalance.value > 69420:
                 #Previous Rapidfire with increased value failed, try with lower value up to 69420.
                 inbound_cans = auto_rebalance_channels.filter(remote_pubkey=rebalance.last_hop_pubkey).filter(auto_rebalance=True, inbound_can__gte=1)
                 if await inbound_cans_len(inbound_cans) > 0 and len(outbound_cans) > 0:

--- a/rebalancer.py
+++ b/rebalancer.py
@@ -111,7 +111,7 @@ async def run_rebalancer(rebalance, worker):
                 #Previous Rapidfire with increased value failed, try with lower value up to 69420.
                 if rebalance.duration > 1:
                     next_value = await estimate_liquidity ( payment_response )
-                    if next_value < 69420:
+                    if next_value < 1000:
                         next_rebalance = None
                         return next_rebalance
                 else:
@@ -139,12 +139,13 @@ def estimate_liquidity( payment ):
             for attempt in payment.htlcs:
                 total_hops=len(attempt.route.hops)
                 #Failure Codes https://github.com/lightningnetwork/lnd/blob/9f013f5058a7780075bca393acfa97aa0daec6a0/lnrpc/lightning.proto#L4200
-                if (attempt.failure.code in (1,2) and attempt.failure.failure_source_index == total_hops) or attempt.failure.code == 12:
-                    #Failure 1,2 from last hop indicating liquidity available, failure 12 shows fees in sufficient but liquidity available
-                    estimated_liquidity += attempt.route.total_amt
+                #print (f"{datetime.now().strftime('%c')} : DEBUG Liquidity Estimation {attempt.attempt_id=} {attempt.status=} {attempt.failure.code=} {attempt.failure.failure_source_index=} {total_hops=} {attempt.route.total_amt=} {payment.value_msat/1000=} {estimated_liquidity=} {payment.payment_hash=}")
+                if attempt.failure.failure_source_index == total_hops:
+                    #Failure from last hop indicating liquidity available
+                    estimated_liquidity = attempt.route.total_amt if attempt.route.total_amt > estimated_liquidity else estimated_liquidity
                     chan_id=attempt.route.hops[len(attempt.route.hops)-1].chan_id
-                    print (f"{datetime.now().strftime('%c')} : Liquidity Estimation {attempt.attempt_id=} {attempt.status=} {attempt.failure.code=} {chan_id=} {attempt.route.total_amt=} {payment.value_msat/1000=} {estimated_liquidity=} {payment.payment_hash=}")
-        print (f"{datetime.now().strftime('%c')} : Final Estimated Liquidity {estimated_liquidity=} {payment.payment_hash=} {payment.status=}")
+                    #print (f"{datetime.now().strftime('%c')} : DEBUG Liquidity Estimation {attempt.attempt_id=} {attempt.status=} {attempt.failure.code=} {chan_id=} {attempt.route.total_amt=} {payment.value_msat/1000=} {estimated_liquidity=} {payment.payment_hash=}")
+        print (f"{datetime.now().strftime('%c')} : Estimated Liquidity {estimated_liquidity=} {payment.payment_hash=} {payment.status=} {payment.failure_reason=}")
     except Exception as e:
         print (f"{datetime.now().strftime('%c')} : Error estimating liquidity: {str(e)=}")
         estimated_liquidity = 0


### PR DESCRIPTION
After removing update AR Target, it is necessary to try failed rebalances with reduced amounts until give up (69420) limit. Failed rebalances will be tried by halving the amount.