### PR TITLE
Add local_settings form component

### DIFF
--- a/gui/forms.py
+++ b/gui/forms.py
@@ -63,6 +63,20 @@ class RebalancerForm(forms.ModelForm):
     last_hop_pubkey = forms.CharField(label='funding_txid', max_length=66, required=False)
     duration = forms.IntegerField(label='duration')
 
+class AutoRebalanceForm(forms.Form):	
+    enabled = forms.IntegerField(label='enabled', required=False)	
+    target_percent = forms.FloatField(label='target_percent', required=False)	
+    target_time = forms.IntegerField(label='target_time', required=False)	
+    fee_rate = forms.IntegerField(label='fee_rate', required=False)	
+    outbound_percent = forms.FloatField(label='outbound_percent', required=False)	
+    inbound_percent = forms.FloatField(label='inbound_percent', required=False)	
+    max_cost = forms.FloatField(label='max_cost', required=False)	
+    variance = forms.IntegerField(label='variance', required=False)	
+    wait_period = forms.IntegerField(label='wait_period', required=False)	
+    autopilot = forms.IntegerField(label='autopilot', required=False)	
+    autopilotdays = forms.IntegerField(label='autopilotdays', required=False)
+    update_channels = forms.BooleanField(widget=forms.CheckboxSelectMultiple, required=False)
+
 updates_channel_codes = [
     (0, 'base_fee'),
     (1, 'fee_rate'),

--- a/gui/forms.py
+++ b/gui/forms.py
@@ -63,21 +63,6 @@ class RebalancerForm(forms.ModelForm):
     last_hop_pubkey = forms.CharField(label='funding_txid', max_length=66, required=False)
     duration = forms.IntegerField(label='duration')
 
-class AutoRebalanceForm(forms.Form):
-    chan_id = forms.IntegerField(label='chan_id', required=False)
-    enabled = forms.IntegerField(label='enabled', required=False)
-    target_percent = forms.FloatField(label='target_percent', required=False)
-    target_time = forms.IntegerField(label='target_time', required=False)
-    fee_rate = forms.IntegerField(label='fee_rate', required=False)
-    outbound_percent = forms.FloatField(label='outbound_percent', required=False)
-    inbound_percent = forms.FloatField(label='inbound_percent', required=False)
-    max_cost = forms.FloatField(label='max_cost', required=False)
-    variance = forms.IntegerField(label='variance', required=False)
-    wait_period = forms.IntegerField(label='wait_period', required=False)
-    autopilot = forms.IntegerField(label='autopilot', required=False)
-    autopilotdays = forms.IntegerField(label='autopilotdays', required=False)
-    targetallchannels = forms.BooleanField(widget=forms.CheckboxSelectMultiple, required=False)
-
 updates_channel_codes = [
     (0, 'base_fee'),
     (1, 'fee_rate'),

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -577,7 +577,7 @@
   </table>
 </div>
 {% endif %}
-{% include 'local_settings.html' with settings=local_settings %}
+{% include 'local_settings.html' with settings=local_settings title="Auto-Rebalancer" url='rebalancing' %}
 <div class="w3-container w3-padding-small">
   <h2>Connect To A Peer</h2>
   <div class="w3-container w3-padding-32">

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -577,56 +577,7 @@
   </table>
 </div>
 {% endif %}
-{% if local_settings %}
-<div class="w3-container w3-padding-small">
-  <h2><a href="/rebalancing" target="_blank">Auto-Rebalancer</a> Settings</h2>
-  <table class="w3-table-all w3-centered w3-hoverable">
-    <tr>
-      <th>Key</th>
-      <th>Value</th>
-    </tr>
-    {% for settings in local_settings %}
-    <tr>
-      <td>{{ settings.key }}</td>
-      <td>{{ settings.value|intcomma }}</td>
-    </tr>
-    {% endfor %}
-  </table>
-</div>
-{% endif %}
-<div class="w3-container w3-padding-small">
-  <h2>Update Auto Rebalancer Settings</h2>
-  <div class="w3-container w3-padding-32">
-    <form action="/autorebalance/" method="post">
-      {% csrf_token %}
-      <label title="This enables or disables the auto-scheduling function" for="enabled">Enabled: </label>
-      <input id="enabled" type="number" min="0" max="1" name="enabled">
-      <label title="The % of the total capacity to target as the rebalance amount" for="target_percent">Target Amount (%): </label>
-      <input id="target_percent" type="number" step="0.1" min="0.1" max="100" name="target_percent">
-      <label title="The time spent per individual rebalance attempt" for="target_time">Target Time (min): </label>
-      <input id="target_time" type="number" min="1" max="60" name="target_time">
-      <label title="When a channel is not enabled for targeting; the minimum outbound a channel must have to be a source for refilling another channel" for="outbound_percent">Target Outbound Above (%): </label>
-      <input id="outbound_percent" type="number" step="1" min="1" max="100" name="outbound_percent">
-      <label title="When a channel is enabled for targeting; the maximum inbound a channel can have before selected for auto rebalance" for="inbound_percent">Target Inbound Above (%): </label>
-      <input id="inbound_percent" type="number" step="1" min="1" max="100" name="inbound_percent">
-      <label title="The max rate we can ever use to refill a channel with outbound" for="fee_rate">Global Max Fee Rate (ppm): </label>
-      <input id="fee_rate" type="number" min="1" max="2500" name="fee_rate">
-      <label title="The ppm to target which is the % of the outbound fee rate for the channel being refilled" for="max_cost">Max Cost (%): </label>
-      <input id="max_cost" type="number" step="1" min="1" max="100" name="max_cost">
-      <label title="The % of the target amount to be randomly varied with every rebalance attempt" for="variance">Variance (%): </label>
-      <input id="variance" type="number" min="0" max="100" name="variance">
-      <label title="The minutes we should wait after a failed attempt before trying again" for="wait_period">Wait Period (min): </label>
-      <input id="wait_period" type="number" min="1" max="100" name="wait_period">
-      <label title="This enables or disables the Autopilot function which automatically acts upon suggestions on this page: /actions" for="autopilot">Autopilot: </label>
-      <input id="autopilot" type="number" min="0" max="1" name="autopilot">
-      <label title="Number of days to consider for autopilot. Default 7." for="autopilotdays">AutopilotDays: </label>
-      <input id="autopilotdays" type="number" min="0" max="100" name="autopilotdays">
-      <label title="Apply for all existing channels." for="targetallchannels">Target All Channels:? </label>
-      <input id="targetallchannels" type="checkbox" name="targetallchannels">
-      <input type="submit" value="OK">
-    </form>
-  </div>
-</div>
+{% include 'local_settings.html' with settings=local_settings %}
 <div class="w3-container w3-padding-small">
   <h2>Connect To A Peer</h2>
   <div class="w3-container w3-padding-32">

--- a/gui/templates/local_settings.html
+++ b/gui/templates/local_settings.html
@@ -1,7 +1,7 @@
 <div class="w3-container w3-padding-small">
     <form action="/autorebalance/" method="post">
       {% csrf_token %}
-    <h2>Auto-Rebalancer settings</h2>
+    <h2>{% if url %}<a href='/{{url}}' target='_blank'>{{title}}</a>{% else %}{{title}}{% endif %} settings</h2>
     <div class="w3-container">
       <div class="w3-row-padding w3-container">
         {% for setting in settings %}

--- a/gui/templates/local_settings.html
+++ b/gui/templates/local_settings.html
@@ -7,10 +7,12 @@
         {% for setting in settings %}
         <div class="w3-quarter w3-container">
           <label class="w3-label" title="{{ setting.title }}">{{ setting.label }}</label>
-          <input class="w3-input" id="{{setting.id}}" name="{{setting.id}}" type="number" min="{{setting.min}}" max="{{setting.max}}" step="{{setting.min}}" value="{{setting.value}}"/>
+          <input class="w3-input" id="{{setting.form_id}}" name="{{setting.form_id}}" type="number" min="{{setting.min}}" max="{{setting.max}}" step="{{setting.min}}" value="{{setting.value}}"/>
         </div>
         {% endfor %}
         <div class="w3-quarter w3-container">
+          <input class="w3-check" id="update_channels" type="checkbox" name="update_channels"/>
+          <label class="w3-validate">Update Channels</label>
           <input class="w3-button w3-margin-top" type="submit" value="OK">
         </div>
       </div>

--- a/gui/templates/local_settings.html
+++ b/gui/templates/local_settings.html
@@ -1,0 +1,21 @@
+<div class="w3-container w3-padding-small">
+    <form action="/autorebalance/" method="post">
+      {% csrf_token %}
+    <h2>Auto-Rebalancer settings</h2>
+    <div class="w3-container">
+      <div class="w3-row-padding w3-container">
+        {% for setting in settings %}
+        <div class="w3-quarter w3-container">
+          <label class="w3-label" title="{{ setting.title }}">{{ setting.label }}</label>
+          <input class="w3-input" id="{{setting.id}}" name="{{setting.id}}" type="number" min="{{setting.min}}" max="{{setting.max}}" step="{{setting.min}}" value="{{setting.value}}"/>
+        </div>
+        {% endfor %}
+        <div class="w3-quarter w3-container">
+          <input class="w3-check" id="targetallchannels" type="checkbox" name="targetallchannels"/>
+          <label class="w3-validate">Target All Channels </label>
+          <input class="w3-btn" type="submit" value="OK">
+        </div>
+      </div>
+    </div>
+  </form>
+</div>

--- a/gui/templates/local_settings.html
+++ b/gui/templates/local_settings.html
@@ -11,9 +11,7 @@
         </div>
         {% endfor %}
         <div class="w3-quarter w3-container">
-          <input class="w3-check" id="targetallchannels" type="checkbox" name="targetallchannels"/>
-          <label class="w3-validate">Target All Channels </label>
-          <input class="w3-btn" type="submit" value="OK">
+          <input class="w3-button w3-margin-top" type="submit" value="OK">
         </div>
       </div>
     </div>

--- a/gui/templates/rebalancing.html
+++ b/gui/templates/rebalancing.html
@@ -134,7 +134,7 @@
   <center><h1>You dont have any rebalancer requests yet.</h1></center>
 </div>
 {% endif %}
-{% include 'local_settings.html' with settings=local_settings %}
+{% include 'local_settings.html' with settings=local_settings title='Auto-Rebalancer' %}
 {% if channels %}
 <div class="w3-container w3-padding-small">
   <h2>Manual Rebalancer Request</h2>

--- a/gui/templates/rebalancing.html
+++ b/gui/templates/rebalancing.html
@@ -134,56 +134,7 @@
   <center><h1>You dont have any rebalancer requests yet.</h1></center>
 </div>
 {% endif %}
-{% if local_settings %}
-<div class="w3-container w3-padding-small">
-  <h2>Auto-Rebalancer Settings</h2>
-  <table class="w3-table-all w3-centered w3-hoverable">
-    <tr>
-      <th>Key</th>
-      <th>Value</th>
-    </tr>
-    {% for settings in local_settings %}
-    <tr>
-      <td>{{ settings.key }}</td>
-      <td>{{ settings.value|intcomma }}</td>
-    </tr>
-    {% endfor %}
-  </table>
-</div>
-{% endif %}
-<div class="w3-container w3-padding-small">
-  <h2>Update Auto Rebalancer Settings</h2>
-  <div class="w3-container w3-padding-32">
-    <form action="/autorebalance/" method="post">
-      {% csrf_token %}
-      <label title="This enables or disables the auto-scheduling function" for="enabled">Enabled: </label>
-      <input id="enabled" type="number" min="0" max="1" name="enabled">
-      <label title="The % of the total capacity to target as the rebalance amount" for="target_percent">Target Amount (%): </label>
-      <input id="target_percent" type="number" step="0.1" min="0.1" max="100" name="target_percent">
-      <label title="The time spent per individual rebalance attempt" for="target_time">Target Time (min): </label>
-      <input id="target_time" type="number" min="1" max="60" name="target_time">
-      <label title="When a channel is not enabled for targeting; the minimum outbound a channel must have to be a source for refilling another channel" for="outbound_percent">Target Outbound Above (%): </label>
-      <input id="outbound_percent" type="number" step="1" min="1" max="100" name="outbound_percent">
-      <label title="When a channel is enabled for targeting; the maximum inbound a channel can have before selected for auto rebalance" for="inbound_percent">Target Inbound Above (%): </label>
-      <input id="inbound_percent" type="number" step="1" min="1" max="100" name="inbound_percent">
-      <label title="The max rate we can ever use to refill a channel with outbound" for="fee_rate">Global Max Fee Rate (ppm): </label>
-      <input id="fee_rate" type="number" min="1" max="2500" name="fee_rate">
-      <label title="The ppm to target which is the % of the outbound fee rate for the channel being refilled" for="max_cost">Max Cost (%): </label>
-      <input id="max_cost" type="number" step="1" min="1" max="100" name="max_cost">
-      <label title="The % of the target amount to be randomly varied with every rebalance attempt" for="variance">Variance (%): </label>
-      <input id="variance" type="number" min="0" max="100" name="variance">
-      <label title="The minutes we should wait after a failed attempt before trying again" for="wait_period">Wait Period (min): </label>
-      <input id="wait_period" type="number" min="1" max="100" name="wait_period">
-      <label title="This enables or disables the Autopilot function which automatically acts upon suggestions on this page: /actions" for="autopilot">Autopilot: </label>
-      <input id="autopilot" type="number" min="0" max="1" name="autopilot">
-      <label title="Number of days to consider for autopilot. Default 7. " for="autopilotdays">AutopilotDays: </label>
-      <input id="autopilotdays" type="number" min="0" max="100" name="autopilotdays">
-      <label title="Target All Channels for applicable channel level settings. Uncheck if you only want to update local settings for future channels." for="targetallchannels">AllChannels?: </label>
-      <input id="targetallchannels" type="checkbox" name="targetallchannels">
-      <input type="submit" value="OK">
-    </form>
-  </div>
-</div>
+{% include 'local_settings.html' with settings=local_settings %}
 {% if channels %}
 <div class="w3-container w3-padding-small">
   <h2>Manual Rebalancer Request</h2>

--- a/gui/views.py
+++ b/gui/views.py
@@ -2059,18 +2059,7 @@ def auto_rebalance(request):
                 {'all': False, 'value': 30, 'parse': lambda x: x,'id': 'AR-WaitPeriod'},
                 {'all': False, 'value': 0, 'parse': lambda x: x,'id': 'AR-Autopilot'},
                 {'all': False, 'value': 7, 'parse': lambda x: x,'id': 'AR-APDays'}]
-        target_chan_id = request.POST.get('chan_id')
-        all = request.POST.get('targetallchannels')
-
-        if target_chan_id is not None:
-            target_channel = Channels.objects.filter(chan_id=target_chan_id)
-            if len(target_channel) == 1:
-                target_channel = target_channel[0]
-                target_channel.auto_rebalance = target_channel.auto_rebalance == False
-                target_channel.save()
-                messages.success(request, 'Updated auto rebalancer status for: ' + str(target_channel.chan_id))
-            else:
-                messages.error(request, 'Failed to update auto rebalancer status of channel: ' + str(target_chan_id))
+        
         for field in form:
             value = request.POST.get(field['id'])
             if value is not None:
@@ -2083,15 +2072,16 @@ def auto_rebalance(request):
             if db_value.value != str(value):
                 db_value.value = value
                 db_value.save()
-                if all and field['all'] == True:
-                    if field['id'] == 'AR-Target%':
-                        Channels.objects.all().update(ar_amt_target=Round(F('capacity')*(value/100), output_field=IntegerField()))
-                    elif field['id'] == 'AR-Outbound%':
-                        Channels.objects.all().update(ar_out_target=value)
-                    elif field['id'] == 'AR-Inbound%':
-                        Channels.objects.all().update(ar_in_target=value)
-                    elif field['id'] == 'AR-MaxCost%':
-                        Channels.objects.all().update(ar_max_cost=value)
+
+                if field['id'] == 'AR-Target%':
+                    Channels.objects.all().update(ar_amt_target=Round(F('capacity')*(value/100), output_field=IntegerField()))
+                elif field['id'] == 'AR-Outbound%':
+                    Channels.objects.all().update(ar_out_target=value)
+                elif field['id'] == 'AR-Inbound%':
+                    Channels.objects.all().update(ar_in_target=value)
+                elif field['id'] == 'AR-MaxCost%':
+                    Channels.objects.all().update(ar_max_cost=value)
+                if field['id'] in ['AR-Target%', 'AR-Outbound%','AR-Inbound%','AR-MaxCost%']:
                     messages.success(request, 'All channels ' + field['id'] + ' updated to: ' + str(value))
                 else:
                     messages.success(request, field['id'] + ' updated to: ' + str(value))


### PR DESCRIPTION
This PR adds a `local-settings.html` component so it can be reused across other pages in a way that:
- local settings table view can be removed since the form already contains the current values to be edited
- the form can be reused across other local settings forms as part of future development (i.e `advanced`, `fees`...)
- the form is responsive and suitable to smaller screens
- only update changes that has been actually changed from `db_value`

screenshot:
<img width="733" alt="image" src="https://user-images.githubusercontent.com/43297242/221660580-d9b876d7-70f6-4343-a341-96cf0df0019f.png">


