### PR TITLE
Fix capacity position liq bar

### DIFF
--- a/gui/static/w3style.css
+++ b/gui/static/w3style.css
@@ -246,3 +246,8 @@ button {cursor: pointer;border-radius: 6px;border-color: rgba(0,0,0,0.1);}
 a {color: #0969da}.dark-mode a {color: #58a6ff}
 a:link {text-decoration: none}
 .dark-mode .w3-hoverable tbody tr:hover,.dark-mode .w3-ul.w3-hoverable li:hover {background-color: #30363d !important}
+progress {border:0;text-align: center;position:relative;min-width: 200px;height: 25px;width: 100%;} 
+progress:before {content: attr(data-label);position:absolute;left:0;right:0;color:white}
+progress::-webkit-progress-bar {border-radius: 4px;background-color: #ff9800;}
+progress::-webkit-progress-value {border-radius: 4px;background-color: #2196F3;}
+progress::-moz-progress-bar {background-color: #2196F3;}

--- a/gui/templates/advanced.html
+++ b/gui/templates/advanced.html
@@ -78,7 +78,7 @@
         <th onclick="sortTable(event.target, 0, 'String', 1, 'a')">Channel ID</th>
         <th onclick="sortTable(event.target, 1, 'String', 1, 'a')">Peer Alias</th>
         <th onclick="sortTable(event.target, 2, ' (', 1)">Outbound Liquidity</th>
-        <th onclick="sortTable(event.target, 3, 'int', 1, 'span')">Capacity</th>
+        <th onclick="sortTable(event.target, 3, 'int', 1, 'progress')">Capacity</th>
         <th onclick="sortTable(event.target, 4, ' (', 1)">Inbound Liquidity</th>
         <th>Channel State</th>
         <th>oRate</th>
@@ -100,7 +100,7 @@
         <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
         <td title="{{ channel.remote_pubkey }}">{% if channel.private == False %}<a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% endif %}{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}{% if channel.private == False %}</a>{% endif %}</td>
         <td>{{ channel.local_balance|intcomma }} ({{ channel.out_percent }}%)</td>
-        <td><div class="w3-orange w3-round"><div class="w3-container w3-round w3-blue" style="height:25px;{% if channel.out_percent > 0 %}width:{{ channel.out_percent|intcomma }}%{% else %}visibility:hidden{% endif %}"><span style="width:200px;justify-content:space-between;display:flex;justify-content:center;">{{ channel.capacity|intcomma }}</span></div></div></td>
+        <td><progress class="w3-round" max="100" value="{{channel.out_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
         <td>{{ channel.remote_balance|intcomma }} ({{ channel.in_percent }}%)</td>
         <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% elif channel.private == True %}style="background-color: rgba(110,118,129,0.4)"{% endif %}>
           {% if channel.is_active == True and channel.private == False %}

--- a/gui/templates/advanced.html
+++ b/gui/templates/advanced.html
@@ -100,7 +100,7 @@
         <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
         <td title="{{ channel.remote_pubkey }}">{% if channel.private == False %}<a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% endif %}{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}{% if channel.private == False %}</a>{% endif %}</td>
         <td>{{ channel.local_balance|intcomma }} ({{ channel.out_percent }}%)</td>
-        <td><progress class="w3-round" max="100" value="{{channel.out_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
+        <td><progress max="100" value="{{channel.out_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
         <td>{{ channel.remote_balance|intcomma }} ({{ channel.in_percent }}%)</td>
         <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% elif channel.private == True %}style="background-color: rgba(110,118,129,0.4)"{% endif %}>
           {% if channel.is_active == True and channel.private == False %}

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -61,7 +61,7 @@
         <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
         <td title="{{ channel.remote_pubkey }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
         <td>{{ channel.local_balance|intcomma }} ({{ channel.outbound_percent }}%)</td>
-        <td><progress class="w3-round" max="100" value="{{channel.outbound_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
+        <td><progress max="100" value="{{channel.outbound_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
         <td>{{ channel.remote_balance|intcomma }} ({{ channel.inbound_percent }}%)</td>
         <td>{{ channel.unsettled_balance|intcomma }} ({{ channel.htlc_count }})</td>
         <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% endif %}>{{ channel.local_fee_rate|intcomma }}</td>
@@ -126,7 +126,7 @@
       <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
       <td title="{{ channel.remote_pubkey }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
       <td>{{ channel.local_balance|intcomma }}</td>
-      <td><progress class="w3-round" max="100" value="{{channel.outbound_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
+      <td><progress max="100" value="{{channel.outbound_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
       <td>{{ channel.remote_balance|intcomma }}</td>
       <td>{{ channel.unsettled_balance|intcomma }}</td>
       <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% endif %}>{{ channel.local_fee_rate|intcomma }}</td>
@@ -188,7 +188,7 @@
       <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
       <td title="{{ channel.remote_pubkey }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
       <td>{{ channel.local_balance|intcomma }}</td>
-      <td><progress class="w3-round" max="100" value="{{channel.outbound_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
+      <td><progress max="100" value="{{channel.outbound_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
       <td>{{ channel.remote_balance|intcomma }}</td>
       <td>{{ channel.unsettled_balance|intcomma }}</td>
       <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% endif %}>{{ channel.local_fee_rate|intcomma }}</td>

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -42,7 +42,7 @@
         <th onclick="sortTable(event.target, 0, 'String', 0, 'a')">Channel ID</th>
         <th onclick="sortTable(event.target, 1, 'String', 0, 'a')">Peer Alias</th>
         <th onclick="sortTable(event.target, 2, ' (')">Outbound Liquidity</th>
-        <th onclick="sortTable(event.target, 3, 'int', 0, 'span')">Capacity</th>
+        <th onclick="sortTable(event.target, 3, 'int', 0, 'progress')">Capacity</th>
         <th onclick="sortTable(event.target, 5, ' (')">Inbound Liquidity</th>
         <th onclick="sortTable(event.target, 6, ' (')">Unsettled</th>
         <th onclick="sortTable(event.target, 7, 'int')">oRate</th>
@@ -61,7 +61,7 @@
         <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
         <td title="{{ channel.remote_pubkey }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
         <td>{{ channel.local_balance|intcomma }} ({{ channel.outbound_percent }}%)</td>
-        <td><div class="w3-orange w3-round"><div class="w3-container w3-round w3-blue" style="height:25px;{% if channel.outbound_percent > 0 %}width:{{ channel.outbound_percent|intcomma }}%{% else %}visibility:hidden{% endif %}"><span style="width:200px;justify-content:space-between;display:flex;justify-content:center;">{{ channel.capacity|intcomma }}</span></div></div></td>
+        <td><progress class="w3-round" max="100" value="{{channel.outbound_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
         <td>{{ channel.remote_balance|intcomma }} ({{ channel.inbound_percent }}%)</td>
         <td>{{ channel.unsettled_balance|intcomma }} ({{ channel.htlc_count }})</td>
         <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% endif %}>{{ channel.local_fee_rate|intcomma }}</td>
@@ -107,7 +107,7 @@
       <th onclick="sortTable(event.target, 0, 'String')">Channel ID</th>
       <th onclick="sortTable(event.target, 1, 'String', 0, 'a')">Peer Alias</th>
       <th onclick="sortTable(event.target, 2, ' (')" width=9%>Outbound Liquidity</th>
-      <th onclick="sortTable(event.target, 3, 'int', 0, 'span')">Capacity</th>
+      <th onclick="sortTable(event.target, 3, 'int', 0, 'progress')">Capacity</th>
       <th onclick="sortTable(event.target, 5, ' (')" width=9%>Inbound Liquidity</th>
       <th onclick="sortTable(event.target, 6, ' (')" width=6%>Unsettled</th>
       <th onclick="sortTable(event.target, 7, 'int')" width=4%>oRate</th>
@@ -126,7 +126,7 @@
       <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
       <td title="{{ channel.remote_pubkey }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
       <td>{{ channel.local_balance|intcomma }}</td>
-      <td><div class="w3-orange w3-round"><div class="w3-container w3-round w3-blue" style="height:25px;{% if channel.outbound_percent > 0 %}width:{{ channel.outbound_percent|intcomma }}%{% else %}visibility:hidden{% endif %}"><span style="width:200px;justify-content:space-between;display:flex;justify-content:center;">{{ channel.capacity|intcomma }}</span></div></div></td>
+      <td><progress class="w3-round" max="100" value="{{channel.outbound_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
       <td>{{ channel.remote_balance|intcomma }}</td>
       <td>{{ channel.unsettled_balance|intcomma }}</td>
       <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% endif %}>{{ channel.local_fee_rate|intcomma }}</td>
@@ -188,7 +188,7 @@
       <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
       <td title="{{ channel.remote_pubkey }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
       <td>{{ channel.local_balance|intcomma }}</td>
-      <td><div class="w3-orange w3-round"><div class="w3-container w3-round w3-blue" style="height:25px;{% if channel.outbound_percent > 0 %}width:{{ channel.outbound_percent|intcomma }}%{% else %}visibility:hidden{% endif %}"><span style="width:200px;justify-content:space-between;display:flex;justify-content:center;">{{ channel.capacity|intcomma }}</span></div></div></td>
+      <td><progress class="w3-round" max="100" value="{{channel.outbound_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
       <td>{{ channel.remote_balance|intcomma }}</td>
       <td>{{ channel.unsettled_balance|intcomma }}</td>
       <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% endif %}>{{ channel.local_fee_rate|intcomma }}</td>

--- a/gui/templates/rebalancing.html
+++ b/gui/templates/rebalancing.html
@@ -30,7 +30,7 @@
         <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
         <td title="{{ channel.remote_pubkey }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
         <td>{{ channel.local_balance|intcomma }} ({{ channel.percent_outbound }}%)</td>
-        <td><progress class="w3-round" max="100" value="{{channel.percent_outbound|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
+        <td><progress max="100" value="{{channel.percent_outbound|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
         <td>{{ channel.remote_balance|intcomma }} ({{ channel.percent_inbound }}%)</td>
         <td {% if channel.percent_outbound >= channel.ar_out_target and channel.auto_rebalance == False %}style="background-color: rgba(46,160,67,0.15);">True{% else %}style="background-color: rgba(248,81,73,0.15)">False{% endif %}</td>
         <td {% if channel.auto_rebalance  == True %}style="background-color: rgba(46,160,67,0.15);">True{% else %}style="background-color: rgba(248,81,73,0.15)">False{% endif %}</td>

--- a/gui/templates/rebalancing.html
+++ b/gui/templates/rebalancing.html
@@ -11,7 +11,7 @@
         <th onclick="sortTable(event.target, 0, 'String')">Channel ID</th>
         <th onclick="sortTable(event.target, 1, 'String', 0, 'a')">Peer Alias</th>
         <th onclick="sortTable(event.target, 2, ' (')">Outbound Liquidity</th>
-        <th onclick="sortTable(event.target, 3, 'int', 0, 'span')">Capacity</th>
+        <th onclick="sortTable(event.target, 3, 'int', 0, 'progress')">Capacity</th>
         <th onclick="sortTable(event.target, 5, ' (')">Inbound Liquidity</th>
         <th><a href="/rebalancing?=2">Rebal Out?</a></th>
         <th><a href="/rebalancing?=1">Enabled?</a></th>
@@ -30,7 +30,7 @@
         <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
         <td title="{{ channel.remote_pubkey }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
         <td>{{ channel.local_balance|intcomma }} ({{ channel.percent_outbound }}%)</td>
-        <td><div class="w3-orange w3-round"><div class="w3-container w3-round w3-blue" style="height:25px;{% if channel.percent_outbound > 0 %}width:{{ channel.percent_outbound|intcomma }}%{% else %}visibility:hidden{% endif %}"><span style="width:200px;justify-content:space-between;display:flex;justify-content:center;">{{ channel.capacity|intcomma }}</span></div></div></td>
+        <td><progress class="w3-round" max="100" value="{{channel.percent_outbound|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
         <td>{{ channel.remote_balance|intcomma }} ({{ channel.percent_inbound }}%)</td>
         <td {% if channel.percent_outbound >= channel.ar_out_target and channel.auto_rebalance == False %}style="background-color: rgba(46,160,67,0.15);">True{% else %}style="background-color: rgba(248,81,73,0.15)">False{% endif %}</td>
         <td {% if channel.auto_rebalance  == True %}style="background-color: rgba(46,160,67,0.15);">True{% else %}style="background-color: rgba(248,81,73,0.15)">False{% endif %}</td>


### PR DESCRIPTION
This PR fixes the position of the capacity label in the liquidity bar when outbound liquidity is low and for when the user uses a different zoom setting.
Issue: 
<img width="181" alt="image" src="https://user-images.githubusercontent.com/43297242/221992000-a5782670-2704-4fdd-bce7-a64658023218.png">
