### PR TITLE
Fix liquidity bar cross-browser issue and table sorting order

### DIFF
--- a/gui/static/w3style.css
+++ b/gui/static/w3style.css
@@ -249,8 +249,6 @@ a:link {text-decoration: none}
 .dark-mode .w3-hoverable tbody tr:hover,.dark-mode .w3-ul.w3-hoverable li:hover {background-color: #30363d !important}
 .dark-mode .w3-green{background-color: #238636!important}.dark-mode .w3-border-green{border-color: #238636!important}
 .dark-mode .w3-red{background-color: #f85149!important}.dark-mode .w3-border-red{border-color: #f85149!important}
-progress {border:0;text-align: center;position:relative;min-width: 200px;height: 25px;width: 100%;} 
-progress:before {content: attr(data-label);position:absolute;left:0;right:0;color:white}
-progress::-webkit-progress-bar {border-radius: 4px;background-color: #ff9800;}
-progress::-webkit-progress-value {border-radius: 4px;background-color: #2196F3;}
-progress::-moz-progress-bar {background-color: #2196F3;}
+.progress {min-width: 200px;height: 25px;width: 100%;position: relative;}
+.progress:before {content: attr(data-label);position: absolute;text-align: center;left: 0;right: 0;}
+.progress .value {display: flex;height: 100%;}

--- a/gui/templates/advanced.html
+++ b/gui/templates/advanced.html
@@ -78,7 +78,7 @@
         <th onclick="sortTable(event.target, 0, 'String', 1, 'a')">Channel ID</th>
         <th onclick="sortTable(event.target, 1, 'String', 1, 'a')">Peer Alias</th>
         <th onclick="sortTable(event.target, 2, ' (', 1)">Outbound Liquidity</th>
-        <th onclick="sortTable(event.target, 3, 'int', 1, 'progress')">Capacity</th>
+        <th onclick="sortTable(event.target, 3, 'int', 1, 'text')">Capacity</th>
         <th onclick="sortTable(event.target, 4, ' (', 1)">Inbound Liquidity</th>
         <th>Channel State</th>
         <th>oRate</th>
@@ -100,7 +100,12 @@
         <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
         <td title="{{ channel.remote_pubkey }}">{% if channel.private == False %}<a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% endif %}{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}{% if channel.private == False %}</a>{% endif %}</td>
         <td>{{ channel.local_balance|intcomma }} ({{ channel.out_percent }}%)</td>
-        <td><progress max="100" value="{{channel.out_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
+        <td>
+          <div class="progress w3-round w3-orange" data-label="{{channel.capacity|intcomma}}">
+            <text style="display:none">{{channel.capacity|intcomma}}</text>
+            <span class="value w3-round w3-blue" style="width:{{channel.out_percent|default:"0"}}%"></span>
+          </div>
+        </td>
         <td>{{ channel.remote_balance|intcomma }} ({{ channel.in_percent }}%)</td>
         <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% elif channel.private == True %}style="background-color: rgba(110,118,129,0.4)"{% endif %}>
           {% if channel.is_active == True and channel.private == False %}

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -146,17 +146,17 @@
         <th onclick="sortTable(event.target, 0, 'String', 0, 'a')">Channel ID</th>
         <th onclick="sortTable(event.target, 1, 'String', 0, 'a')">Peer Alias</th>
         <th onclick="sortTable(event.target, 2, ' (')">Outbound Liquidity</th>
-        <th onclick="sortTable(event.target, 3, 'int', 0, 'progress')">Capacity</th>
-        <th onclick="sortTable(event.target, 5, ' (')">Inbound Liquidity</th>
-        <th onclick="sortTable(event.target, 6, ' (')">Unsettled</th>
-        <th onclick="sortTable(event.target, 7, 'int')">oRate</th>
-        <th onclick="sortTable(event.target, 8, 'int')">oBase</th>
-        <th onclick="sortTable(event.target, 9, ' m (')">o1D</th>
-        <th onclick="sortTable(event.target, 10, ' m (')">i1D</th>
-        <th onclick="sortTable(event.target, 11, ' m (')">o7D</th>
-        <th onclick="sortTable(event.target, 12, ' m (')">i7D</th>
-        <th onclick="sortTable(event.target, 13, 'int')">iRate</th>
-        <th onclick="sortTable(event.target, 14, 'int')">iBase</th>
+        <th onclick="sortTable(event.target, 3, 'int', 0, 'text')">Capacity</th>
+        <th onclick="sortTable(event.target, 4, ' (')">Inbound Liquidity</th>
+        <th onclick="sortTable(event.target, 5, ' (')">Unsettled</th>
+        <th onclick="sortTable(event.target, 6, 'int')">oRate</th>
+        <th onclick="sortTable(event.target, 7, 'int')">oBase</th>
+        <th onclick="sortTable(event.target, 8, ' m (')">o1D</th>
+        <th onclick="sortTable(event.target, 9, ' m (')">i1D</th>
+        <th onclick="sortTable(event.target, 10, ' m (')">o7D</th>
+        <th onclick="sortTable(event.target, 11, ' m (')">i7D</th>
+        <th onclick="sortTable(event.target, 12, 'int')">iRate</th>
+        <th onclick="sortTable(event.target, 13, 'int')">iBase</th>
         <th title="When AR is ENABLED for the channel, keep pulling IN to the channel until its inbound liquidity falls below the iTarget%." width=4%>iTarget%</th>
         <th title="When AR is ENABLED it will refill the channel with outbound liquidity." width=4%>AR</th>
       </tr>
@@ -165,7 +165,12 @@
         <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
         <td title="{{ channel.remote_pubkey }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
         <td>{{ channel.local_balance|intcomma }} ({{ channel.outbound_percent }}%)</td>
-        <td><progress max="100" value="{{channel.outbound_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
+        <td>
+          <div class="progress w3-round w3-orange" data-label="{{channel.capacity|intcomma}}">
+            <text style="display:none">{{channel.capacity|intcomma}}</text>
+            <span class="value w3-round w3-blue" style="width:{{channel.outbound_percent|default:"0"}}%"></span>
+          </div>
+        </td>
         <td>{{ channel.remote_balance|intcomma }} ({{ channel.inbound_percent }}%)</td>
         <td>{{ channel.unsettled_balance|intcomma }} ({{ channel.htlc_count }})</td>
         <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% endif %}>{{ channel.local_fee_rate|intcomma }}</td>
@@ -211,7 +216,7 @@
       <th onclick="sortTable(event.target, 0, 'String')">Channel ID</th>
       <th onclick="sortTable(event.target, 1, 'String', 0, 'a')">Peer Alias</th>
       <th onclick="sortTable(event.target, 2, ' (')" width=9%>Outbound Liquidity</th>
-      <th onclick="sortTable(event.target, 3, 'int', 0, 'progress')">Capacity</th>
+      <th onclick="sortTable(event.target, 3, 'int', 0, 'text')">Capacity</th>
       <th onclick="sortTable(event.target, 5, ' (')" width=9%>Inbound Liquidity</th>
       <th onclick="sortTable(event.target, 6, ' (')" width=6%>Unsettled</th>
       <th onclick="sortTable(event.target, 7, 'int')" width=4%>oRate</th>
@@ -230,7 +235,12 @@
       <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
       <td title="{{ channel.remote_pubkey }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
       <td>{{ channel.local_balance|intcomma }}</td>
-      <td><progress max="100" value="{{channel.outbound_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
+      <td>
+        <div class="progress w3-round w3-orange" data-label="{{channel.capacity|intcomma}}">
+          <text style="display:none">{{channel.capacity|intcomma}}</text>
+          <span class="value w3-round w3-blue" style="width:{{channel.outbound_percent|default:"0"}}%"></span>
+        </div>
+      </td>
       <td>{{ channel.remote_balance|intcomma }}</td>
       <td>{{ channel.unsettled_balance|intcomma }}</td>
       <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% endif %}>{{ channel.local_fee_rate|intcomma }}</td>
@@ -292,7 +302,12 @@
       <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
       <td title="{{ channel.remote_pubkey }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
       <td>{{ channel.local_balance|intcomma }}</td>
-      <td><progress max="100" value="{{channel.outbound_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
+      <td>
+        <div class="progress w3-round w3-orange" data-label="{{channel.capacity|intcomma}}">
+          <text style="display:none">{{channel.capacity|intcomma}}</text>
+          <span class="value w3-round w3-blue" style="width:{{channel.outbound_percent|default:"0"}}%"></span>
+        </div>
+      </td>
       <td>{{ channel.remote_balance|intcomma }}</td>
       <td>{{ channel.unsettled_balance|intcomma }}</td>
       <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% endif %}>{{ channel.local_fee_rate|intcomma }}</td>

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -95,16 +95,16 @@
     <tr>
       <th>Period</th>
       <th>Routed</th>
-      <th>Fees earned/paid</th>
+      <th>Fees earned | paid</th>
       <th>Offchain fees</th>
       <th>Cost (%)</th>
-      <th>Profit</th>
+      <th title="Profit made per outbound [profit per outbound including onchain fees]">Profit/Outbound</th>
       <th>Outbound Utilization</th>
     </tr>
     <tr>
       <td>1-Day</td>
       <td>{{ routed_1day|intcomma }} ({{ routed_1day_amt|intcomma }} sats)</td>
-      <td>{{ earned_1day|intcomma }} [{{ 1day_routed_ppm|intcomma }}]/{{ total_1day_fees|intcomma }} [{{ 1day_payments_ppm|intcomma }}]</td>
+      <td>{{ earned_1day|intcomma }} [{{ 1day_routed_ppm|intcomma }}] | {{ total_1day_fees|intcomma }} [{{ 1day_payments_ppm|intcomma }}]</td>
       <td>{{ onchain_costs_1day|intcomma }}</td>
       <td>{{ percent_cost_1day }}%</td>
       <td>{{ profit_per_outbound_1d|intcomma }} [{{ profit_per_outbound_real_1d|intcomma }}]</td>
@@ -113,7 +113,7 @@
     <tr>
       <td>7-Day</td>
       <td>{{ routed_7day|intcomma }} ({{ routed_7day_amt|intcomma }} sats)</td>
-      <td>{{ earned_7day|intcomma }} [{{ 7day_routed_ppm|intcomma }}]/{{ total_7day_fees|intcomma }} [{{ 7day_payments_ppm|intcomma }}]</td>
+      <td>{{ earned_7day|intcomma }} [{{ 7day_routed_ppm|intcomma }}] | {{ total_7day_fees|intcomma }} [{{ 7day_payments_ppm|intcomma }}]</td>
       <td>{{ onchain_costs_7day|intcomma }}</td>
       <td>{{ percent_cost_7day }}%</td>
       <td>{{ profit_per_outbound_7d|intcomma }} [{{ profit_per_outbound_real_7d|intcomma }}]</td>

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -34,10 +34,10 @@
     <span style="padding:2px 8px;" class="w3-round w3-border w3-border-grey">Active Private Channels: {{ active_private }} / {{ total_private }}</span>
   </h6>
   {% endif %}
-  <h5>Addresses: 
+  <h6 style="word-wrap: break-word">Addresses: 
     {% for addr in node_info.uris %}
-      {{ addr }}
-      <a style="position:absolute;height:25px;width:30px;padding:4px 8px" href="#" data-addr="{{addr}}"  onclick="toogle(this)">
+    <span style="margin-right:40px">{{ addr }}
+      <a style="position:absolute;height:25px;width:30px;padding:4px 8px" href="#" data-addr="{{addr}}" onclick="toogle(this)">
         <svg style="height:21px;width:21px" version="1.1" >
           <path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path>
           <path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path>
@@ -46,8 +46,9 @@
           <path style="fill:#3fb950;stroke:#3fb950;" fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
         </svg>
       </a>
+    </span>
     {% endfor %}
-  </h5>
+  </h6>
 </div>
 <div class="w3-row w3-container w3-padding-small" >
   <table class="w3-col w3-small w3-table-all w3-centered w3-hoverable" style="width:30%">
@@ -146,17 +147,17 @@
         <th onclick="sortTable(event.target, 0, 'String', 0, 'a')">Channel ID</th>
         <th onclick="sortTable(event.target, 1, 'String', 0, 'a')">Peer Alias</th>
         <th onclick="sortTable(event.target, 2, ' (')">Outbound Liquidity</th>
-        <th onclick="sortTable(event.target, 3, 'int', 0, 'text')">Capacity</th>
-        <th onclick="sortTable(event.target, 4, ' (')">Inbound Liquidity</th>
-        <th onclick="sortTable(event.target, 5, ' (')">Unsettled</th>
-        <th onclick="sortTable(event.target, 6, 'int')">oRate</th>
-        <th onclick="sortTable(event.target, 7, 'int')">oBase</th>
-        <th onclick="sortTable(event.target, 8, ' m (')">o1D</th>
-        <th onclick="sortTable(event.target, 9, ' m (')">i1D</th>
-        <th onclick="sortTable(event.target, 10, ' m (')">o7D</th>
-        <th onclick="sortTable(event.target, 11, ' m (')">i7D</th>
-        <th onclick="sortTable(event.target, 12, 'int')">iRate</th>
-        <th onclick="sortTable(event.target, 13, 'int')">iBase</th>
+        <th onclick="sortTable(event.target, 3, 'int', 0, 'progress')">Capacity</th>
+        <th onclick="sortTable(event.target, 5, ' (')">Inbound Liquidity</th>
+        <th onclick="sortTable(event.target, 6, ' (')">Unsettled</th>
+        <th onclick="sortTable(event.target, 7, 'int')">oRate</th>
+        <th onclick="sortTable(event.target, 8, 'int')">oBase</th>
+        <th onclick="sortTable(event.target, 9, ' m (')">o1D</th>
+        <th onclick="sortTable(event.target, 10, ' m (')">i1D</th>
+        <th onclick="sortTable(event.target, 11, ' m (')">o7D</th>
+        <th onclick="sortTable(event.target, 12, ' m (')">i7D</th>
+        <th onclick="sortTable(event.target, 13, 'int')">iRate</th>
+        <th onclick="sortTable(event.target, 14, 'int')">iBase</th>
         <th title="When AR is ENABLED for the channel, keep pulling IN to the channel until its inbound liquidity falls below the iTarget%." width=4%>iTarget%</th>
         <th title="When AR is ENABLED it will refill the channel with outbound liquidity." width=4%>AR</th>
       </tr>
@@ -165,12 +166,7 @@
         <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
         <td title="{{ channel.remote_pubkey }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
         <td>{{ channel.local_balance|intcomma }} ({{ channel.outbound_percent }}%)</td>
-        <td>
-          <div class="progress w3-round w3-orange" data-label="{{channel.capacity|intcomma}}">
-            <text style="display:none">{{channel.capacity|intcomma}}</text>
-            <span class="value w3-round w3-blue" style="width:{{channel.outbound_percent|default:"0"}}%"></span>
-          </div>
-        </td>
+        <td><progress max="100" value="{{channel.outbound_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
         <td>{{ channel.remote_balance|intcomma }} ({{ channel.inbound_percent }}%)</td>
         <td>{{ channel.unsettled_balance|intcomma }} ({{ channel.htlc_count }})</td>
         <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% endif %}>{{ channel.local_fee_rate|intcomma }}</td>
@@ -216,7 +212,7 @@
       <th onclick="sortTable(event.target, 0, 'String')">Channel ID</th>
       <th onclick="sortTable(event.target, 1, 'String', 0, 'a')">Peer Alias</th>
       <th onclick="sortTable(event.target, 2, ' (')" width=9%>Outbound Liquidity</th>
-      <th onclick="sortTable(event.target, 3, 'int', 0, 'text')">Capacity</th>
+      <th onclick="sortTable(event.target, 3, 'int', 0, 'progress')">Capacity</th>
       <th onclick="sortTable(event.target, 5, ' (')" width=9%>Inbound Liquidity</th>
       <th onclick="sortTable(event.target, 6, ' (')" width=6%>Unsettled</th>
       <th onclick="sortTable(event.target, 7, 'int')" width=4%>oRate</th>
@@ -235,12 +231,7 @@
       <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
       <td title="{{ channel.remote_pubkey }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
       <td>{{ channel.local_balance|intcomma }}</td>
-      <td>
-        <div class="progress w3-round w3-orange" data-label="{{channel.capacity|intcomma}}">
-          <text style="display:none">{{channel.capacity|intcomma}}</text>
-          <span class="value w3-round w3-blue" style="width:{{channel.outbound_percent|default:"0"}}%"></span>
-        </div>
-      </td>
+      <td><progress max="100" value="{{channel.outbound_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
       <td>{{ channel.remote_balance|intcomma }}</td>
       <td>{{ channel.unsettled_balance|intcomma }}</td>
       <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% endif %}>{{ channel.local_fee_rate|intcomma }}</td>
@@ -302,12 +293,7 @@
       <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
       <td title="{{ channel.remote_pubkey }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
       <td>{{ channel.local_balance|intcomma }}</td>
-      <td>
-        <div class="progress w3-round w3-orange" data-label="{{channel.capacity|intcomma}}">
-          <text style="display:none">{{channel.capacity|intcomma}}</text>
-          <span class="value w3-round w3-blue" style="width:{{channel.outbound_percent|default:"0"}}%"></span>
-        </div>
-      </td>
+      <td><progress max="100" value="{{channel.outbound_percent|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
       <td>{{ channel.remote_balance|intcomma }}</td>
       <td>{{ channel.unsettled_balance|intcomma }}</td>
       <td {% if channel.local_disabled == True %}style="background-color: rgba(248,81,73,0.15);"{% endif %}>{{ channel.local_fee_rate|intcomma }}</td>

--- a/gui/templates/rebalancing.html
+++ b/gui/templates/rebalancing.html
@@ -11,26 +11,31 @@
         <th onclick="sortTable(event.target, 0, 'String')">Channel ID</th>
         <th onclick="sortTable(event.target, 1, 'String', 0, 'a')">Peer Alias</th>
         <th onclick="sortTable(event.target, 2, ' (')">Outbound Liquidity</th>
-        <th onclick="sortTable(event.target, 3, 'int', 0, 'progress')">Capacity</th>
-        <th onclick="sortTable(event.target, 5, ' (')">Inbound Liquidity</th>
+        <th onclick="sortTable(event.target, 3, 'int', 0, 'text')">Capacity</th>
+        <th onclick="sortTable(event.target, 4, ' (')">Inbound Liquidity</th>
         <th><a href="/rebalancing?=2">Rebal Out?</a></th>
         <th><a href="/rebalancing?=1">Enabled?</a></th>
-        <th onclick="sortTable(event.target, 8, '%')" title="This ratio must be below the channel's Max Cost %.">Fee Ratio</th>
-        <th onclick="sortTable(event.target, 9, 'String')">Rebal In?</th>
+        <th onclick="sortTable(event.target, 7, '%')" title="This ratio must be below the channel's Max Cost %.">Fee Ratio</th>
+        <th onclick="sortTable(event.target, 8, 'String')">Rebal In?</th>
         <th title="When AR is ENABLED for the channel, the size of the rebalance attempts that should be tried during attempts to refill the channel.">Target Amt</th>
         <th title="When AR is ENABLED, the maximum percentage amount of the local fee rate that can be used for the max rebalancing cost.">Max Cost %</th>
         <th title="When AR is NOT ENABLED for the channel, keep pushing OUT the channel until its outbound liquidity falls below the oTarget%.">oTarget%</th>
         <th title="When AR is ENABLED for the channel, keep pulling IN to the channel until its inbound liquidity falls below the iTarget%.">iTarget%</th>
         <th>AR</th>
         <th title="The rate of successful rebalances on this channel.">7-Day Rate</th>
-        <th onclick="sortTable(event.target, 16, 'String')">Active</th>
+        <th onclick="sortTable(event.target, 15, 'String')">Active</th>
       </tr>
       {% for channel in channels %}
       <tr>
         <td title="{{ channel.funding_txid }}:{{ channel.output_index }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
         <td title="{{ channel.remote_pubkey }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_pubkey }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_pubkey|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
         <td>{{ channel.local_balance|intcomma }} ({{ channel.percent_outbound }}%)</td>
-        <td><progress max="100" value="{{channel.percent_outbound|default:"0"|intcomma}}" data-label="{{ channel.capacity|intcomma }}">{{ channel.capacity|intcomma }}</progress></td>
+        <td>
+          <div class="progress w3-round w3-orange" data-label="{{channel.capacity|intcomma}}">
+            <text style="display:none">{{channel.capacity|intcomma}}</text>
+            <span class="value w3-round w3-blue" style="width:{{channel.percent_outbound|default:"0"}}%"></span>
+          </div>
+        </td>
         <td>{{ channel.remote_balance|intcomma }} ({{ channel.percent_inbound }}%)</td>
         <td {% if channel.percent_outbound >= channel.ar_out_target and channel.auto_rebalance == False %}style="background-color: rgba(46,160,67,0.15);">True{% else %}style="background-color: rgba(248,81,73,0.15)">False{% endif %}</td>
         <td {% if channel.auto_rebalance  == True %}style="background-color: rgba(46,160,67,0.15);">True{% else %}style="background-color: rgba(248,81,73,0.15)">False{% endif %}</td>


### PR DESCRIPTION
Remove progress bar element (poor corss-browser api/support) and fix table sorting order.
Tested on: chrome, firefox, safari(mobile), edge

PS: Fix copy button position overlay and renamed profit column to `Profit/Outbound`