### PR TITLE
Add Home auto refresh from API

### DIFF
--- a/gui/templates/base.html
+++ b/gui/templates/base.html
@@ -123,6 +123,14 @@
       if (document.cookie.includes("privacy=soft")) document.body.classList.toggle("soft-encrypted")
       else if (document.cookie.includes("privacy=hard")) document.body.classList.toggle("encrypted")
     })
+
+    async function auto_refresh(async_callback) {
+      await sleep(21000)
+      while(document.hidden) {
+        await sleep(100)
+      }
+      await async_callback()
+    }
     //END: BASE CONFIG
     //-------------------------------------------------------------------------------------------------------------------------
   </script>

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -906,8 +906,6 @@
     byId('confirmed').innerHTML = `Confirmed: ${node_info.balance.confirmed.intcomma()}`
     byId('unconfirmed').innerHTML = `Unconfirmed: ${node_info.balance.unconfirmed.intcomma()}`
     byId('limbo').innerHTML = `Limbo: ${node_info.balance.limbo.intcomma()}`
-    
-    return node_info
   }
   function build(id, template_arg, channels){
     if(!addTitle(id, channels)){
@@ -918,11 +916,12 @@
     channels.forEach(ch => table.append(template.render(ch)))
   }
   async function buildMain() {
+    const node_info = await GET('node_info', {data: {limit:1}})
     const inv_rev_task = GET('invoices', {data: {state: 1, is_revenue: true, settle_date__gte: _7days_ago}})
     const onchain_task = GET('onchain', {data: {time_stamp__gte: _7days_ago} })
     const forwards7d_task = GET('forwards', {data: {forward_date__gte: _7days_ago} })
     const payments_task = GET('payments', {data: {creation_date__gte: _7days_ago, status: 2} })
-    const node_info = buildMainStats(await GET('node_info', {data: {}}))
+    buildMainStats(node_info)
     const closures_task = GET('closures', {data: {close_height__gte: (node_info.block.height - 1008) } })
 
     let [updates, pending_htlcs, active, inactive, private] = [0,0,[],[],[]]
@@ -951,13 +950,7 @@
     build('Pending Force Closed', pending_fclosed_template, node_info.pending_force_closed||[])
     build_routed(forwards7d)
     build_payments(payments7d)
-    async function auto_refresh(){
-      while(document.hidden) {
-        await sleep(500)
-      }
-      await buildMain()
-    }
-    setTimeout(auto_refresh, 21000)
+    await auto_refresh(buildMain)
   }
   document.addEventListener('DOMContentLoaded', async () => { 
     await buildMain()

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -953,11 +953,12 @@
     await auto_refresh(buildMain)
   }
   document.addEventListener('DOMContentLoaded', async () => { 
-    await buildMain()
+    const builder = buildMain()
     const invoices_task = GET('invoices', {data: {state__lt: 2, limit: 10} })
     const failedHTLCs_task = GET('failedhtlcs', {data: {wire_failure__lt: 99, limit:10} })
     build_invoices((await invoices_task).results)
     build_failedHTLC((await failedHTLCs_task).results)
+    await builder
   })
 </script>
 {% endblock %}

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -147,7 +147,7 @@
   <a class="w3-bar-item w3-hover-blue" href="/batch" target="_blank">Batching</a>
   <a class="w3-bar-item w3-hover-blue" href="/advanced" target="_blank">Advanced Settings</a>
 </div>
-<div id="active_channels_container" class="w3-container w3-padding-small">
+<div id="active_channels_container" style="display:none" class="w3-container w3-padding-small">
   <div class="w3-container w3-padding-small table" style="overflow:auto;max-height:1000px">
     <table class="w3-table-all w3-centered w3-hoverable">
       <thead>
@@ -174,7 +174,7 @@
     </table>
   </div>
 </div>
-<div id="inactive_channels_container" class="w3-container w3-padding-small">
+<div id="inactive_channels_container" style="display:none" class="w3-container w3-padding-small">
   <table class="w3-table-all w3-centered w3-hoverable">
     <thead>
       <tr>
@@ -199,7 +199,7 @@
     <tbody id="inactive_channels"></tbody>
   </table>
 </div>
-<div id="private_channels_container" class="w3-container w3-padding-small">
+<div id="private_channels_container" style="display:none" class="w3-container w3-padding-small">
   <table class="w3-table-all w3-centered w3-hoverable">
     <thead>
       <tr>
@@ -222,7 +222,7 @@
     <tbody id="private_channels"></tbody>
   </table>
 </div>
-<div id="pending_open_container" class="w3-container w3-padding-small">
+<div id="pending_open_container" style="display:none" class="w3-container w3-padding-small">
   <table class="w3-table-all w3-centered w3-hoverable">
     <thead>
       <tr>
@@ -245,7 +245,7 @@
     <tbody id="pending_open"></tbody>
   </table>
 </div>
-<div id="pending_closed_container" class="w3-container w3-padding-small">
+<div id="pending_closed_container" style="display:none" class="w3-container w3-padding-small">
   <table class="w3-table-all w3-centered w3-hoverable">
     <thead>
       <tr>
@@ -262,7 +262,7 @@
     <tbody id="pending_closed"></tbody>
   </table>
 </div>
-<div id="pending_force_closed_container" class="w3-container w3-padding-small">
+<div id="pending_force_closed_container" style="display:none" class="w3-container w3-padding-small">
   <table class="w3-table-all w3-centered w3-hoverable">
     <thead>
       <tr>
@@ -279,7 +279,7 @@
     <tbody id="pending_force_closed"></tbody>
   </table>
 </div>
-<div id="waiting_for_close_container" class="w3-container w3-padding-small">
+<div id="waiting_for_close_container" style="display:none" class="w3-container w3-padding-small">
   <table class="w3-table-all w3-centered w3-hoverable">
     <thead>
       <tr>
@@ -296,7 +296,7 @@
     <tbody id="waiting_for_close"></tbody>
   </table>
 </div>
-<div id="routed_container" class="w3-container w3-padding-small">
+<div id="routed_container" style="display:none" class="w3-container w3-padding-small">
   <table id="forwardsTable" class="w3-table-all w3-centered w3-hoverable">
     <thead>
       <tr>
@@ -323,7 +323,7 @@
   </table>
 </div>
 {% include 'rebalances_table.html' with count=10 load_count=10 title='<a href="/rebalances" target="_blank">Rebalance Requests</a>' %}
-<div id="payments_container" class="w3-container w3-padding-small">
+<div id="payments_container" style="display:none" class="w3-container w3-padding-small">
   <table class="w3-table-all w3-centered w3-hoverable">
     <thead>
       <tr>
@@ -342,7 +342,7 @@
     <tbody id="payments"></tbody>
   </table>
 </div>
-<div id="invoices_container" class="w3-container w3-padding-small">
+<div id="invoices_container" style="display:none" class="w3-container w3-padding-small">
   <table class="w3-table-all w3-centered w3-hoverable">
     <thead>
       <tr>
@@ -360,7 +360,7 @@
     <tbody id="invoices"></tbody>
   </table>
 </div>
-<div id="failed_htlcs_container" class="w3-container w3-padding-small">
+<div id="failed_htlcs_container" style="display:none" class="w3-container w3-padding-small">
   <table id="failedhtlcsTable" class="w3-table-all w3-centered w3-hoverable">
     <thead>
       <tr>

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -89,7 +89,7 @@
         <th id="confirmed" colspan="2" class="w3-border-bottom w3-border-right">Confirmed: 0</th>
         <th id="unconfirmed" class="w3-border-bottom w3-border-right">Unconfirmed: 0</th>
         <th id="limbo" class="w3-border-bottom w3-border-right">Limbo: 0</th>
-        <th id="pending_htlcs" class="w3-border-bottom w3-border-right">Pending HTLCs: 0</th>
+        <th class="w3-border-bottom w3-border-right"><a href="/pending_htlcs" target="_blank">Pending HTLCs</a>: <span id="pending_htlcs">0</span></th>
         <th class="w3-border-bottom">
           <form method="post" action="/newaddress/">
             {% csrf_token %}
@@ -717,7 +717,7 @@
     }
     return sum
   }
-  async function update_summary(payments7d, onchain_task, closures_task, active, inactive, private, forwards_summary, inv_rev_task){
+  async function update_summary(node_info, payments7d, onchain_task, closures_task, active, inactive, private, forwards_summary, inv_rev_task){
     let offChain = {d1: {fee:0, amt:0, inv_rev:0}, d7: {fee:0, amt:0, inv_rev:0} }
     for(p of payments7d){
       if(adjustTZ(p.creation_date) >= _1day_ago){
@@ -741,7 +741,7 @@
       chainCosts.d7 += tx.fee
     }
     for(close of (await closures_task).results){
-      if(close.close_height >= ({{node_info.block_height}} - 144)){
+      if(close.close_height >= (node_info.block.height - 144)){
         chainCosts.d1 += close.closing_costs
       }
       chainCosts.d7 += close.closing_costs
@@ -946,8 +946,8 @@
     const onchain_task = GET('onchain', {data: {time_stamp__gte: _7days_ago} })
     const forwards7d_task = GET('forwards', {data: {forward_date__gte: _7days_ago} })
     const payments_task = GET('payments', {data: {creation_date__gte: _7days_ago, status: 2} })
-    const closures_task = GET('closures', {data: {close_height__gte: ({{node_info.block_height}} - 1008) } })
     const node_info = buildMainStats(await GET('node_info', {data: {}}))
+    const closures_task = GET('closures', {data: {close_height__gte: (node_info.block.height - 1008) } })
 
     let [updates, pending_htlcs, active, inactive, private] = [0,0,[],[],[]]
     for (ch of (await GET('channels', {data: {is_open:true} })).results){ //basic setup
@@ -963,12 +963,12 @@
     }
 
     byId("updates").innerHTML = updates.intcomma()
-    byId("pending_htlcs").innerHTML = `<a href="/pending_htlcs" target="_blank">Pending HTLCs</a>: ${pending_htlcs.intcomma()}`
+    byId("pending_htlcs").innerHTML = pending_htlcs.intcomma()
 
     let [forwards7d, payments7d] = [(await forwards7d_task).results, (await payments_task).results]
     let [forwards_sum, forwards_summary] = process_forwards(forwards7d)
     let [activeSum, privateSum, inactiveSum] = [build_active(active, forwards_sum), build_private(private), build_inactive(inactive)]
-    update_summary(payments7d, onchain_task, closures_task, activeSum, inactiveSum, privateSum, forwards_summary, inv_rev_task)
+    update_summary(node_info, payments7d, onchain_task, closures_task, activeSum, inactiveSum, privateSum, forwards_summary, inv_rev_task)
     build_pending_open(node_info.pending_open||[])
     build_pending_closed(node_info.pending_closed||[])
     build_wating_close(node_info.waiting_for_close||[])

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -658,9 +658,10 @@
   function addTitle(id, results, title = null){
     const container = byId(id.toLowerCase().replace(" ", "_") + '_container')
     if (results.length == 0) {
-      container.remove()
+      container?.remove()
       return false
     }
+    if (container.querySelector('h2')) container.querySelector('h2').innerHTML = null
     container.insertAdjacentHTML('afterbegin', `<h2>${title || id}</h2>`)
     return true
   }
@@ -670,6 +671,7 @@
 
     const [activeChannels, template] = [byId("active_channels"), use(detailed_ch_template)]
 
+    activeChannels.innerHTML = null
     channels.map(ch => { //derived properties
       ch.inbound_can = ch.percent_inbound / ch.ar_in_target
       ch.fee_ratio = ch.local_fee_rate == 0 ? 100 : parseInt(ch.remote_fee_rate*100/ch.local_fee_rate)
@@ -705,7 +707,7 @@
       .forEach(ch => activeChannels.append(template.render(ch)))
 
     byId('public_capacity').innerHTML = sum.capacity.intcomma()
-    return update_sum('active_', sum)
+    return update_liq('active_', sum)
   }
   function build_private(channels){
     let act = {outbound: 0, inbound: 0}, ina = {outbound: 0, inbound: 0} 
@@ -713,6 +715,7 @@
     if(!addTitle("Private Channels", channels)) return Object.assign({}, sum, {outbound: act.outbound + ina.outbound, inbound: act.inbound + ina.inbound})
 
     let [capacity, active_count, table, template] = [0,0,byId('private_channels'),use(private_ch_template)]
+    table.innerHTML = null
     channels.forEach(ch => {
       capacity += ch.capacity
       if(ch.is_active) {
@@ -742,6 +745,7 @@
     if(!addTitle("Inactive Channels", channels)) return sum
 
     const table = byId('inactive_channels'), template = use(inactive_ch_template), public_capacity = byId('public_capacity')
+    table.innerHTML = null
     channels.forEach(ch => {
       sum.capacity += ch.capacity
       sum.inbound += ch.remote_balance
@@ -751,14 +755,13 @@
     })
 
     public_capacity.innerHTML = (public_capacity.innerHTML.toInt() + sum.capacity).intcomma()
-    return update_sum('inactive_', sum)
+    return update_liq('inactive_', sum)
   }
-  function update_sum(status, sum){
+  function update_liq(status, sum){
     for (id of ['inbound', 'outbound', 'unsettled']){
       const [value, total] = [sum[id], byId('total_'+id)]
 
       byId(status+id).innerHTML = value.intcomma()
-      total.innerHTML = (total.innerHTML.toInt() + value).intcomma()
     }
     return sum
   }
@@ -801,10 +804,14 @@
       return result
     }
     
+    byId('total_inbound').innerHTML = (active.inbound + inactive.inbound).intcomma()
+    byId('total_outbound').innerHTML = (active.outbound + inactive.outbound).intcomma()
+    byId('total_unsettled').innerHTML = (active.unsettled + inactive.unsettled).intcomma()
+
     const public = merge(active, inactive), sum = merge(public, private)
     const [total_outbound, total_bal] = [sum.outbound || 1, byId('total_balance')]
     byId('liq_ratio').innerHTML = (public.inbound*100/public.outbound||1).intcomma()+'%'
-    total_bal.innerHTML = (total_bal.innerHTML.toInt() + sum.outbound).intcomma()
+    total_bal.innerHTML = ({{total_balance}} + sum.outbound).intcomma()
 
     for(d of [1,7]){ //build 1 & 7 days table statistics
       const earned = forwards_summary[`earned${d}d`]+offChain[`d${d}`].inv_rev, routed = {'amt':forwards_summary[`o${d}d`],'count':forwards_summary[`o${d}dc`]}, chaincosts = chainCosts[`d${d}`], offchain = offChain[`d${d}`], costs = chaincosts + offchain.fee
@@ -844,6 +851,7 @@
 
     if(!addTitle('Routed', forwards, `Last 20 <a href="/forwards" target="_blank">Payments Routed</a>`)) return
     const table = byId('routed')
+    table.innerHTML = null
     for(f of forwards.slice(0,20)){
       f.amt_in = f.amt_in_msat/1000
       f.amt_out = f.amt_out_msat/1000
@@ -857,6 +865,7 @@
 
     if(!addTitle('Payments', payments, `Last 10 <a href="/payments" target="_blank">Payments</a>`)) return
     const table = byId('payments')
+    table.innerHTML = null
     for(p of payments.slice(0,10)){
       p.ppm = p.fee*1000000/p.value
       table.append(template.render(p))
@@ -903,12 +912,11 @@
     }
     return [forwards_sum, forwards_summary]
   }
-  document.addEventListener('DOMContentLoaded', async () =>{
-    const invoices_task = GET('invoices', {data: {state__lt: 2, limit: 10} })
+  
+  async function buildMain() {
     const inv_rev_task = GET('invoices', {data: {state: 1, is_revenue: true, settle_date__gte: _7days_ago}})
     const onchain_task = GET('onchain', {data: {time_stamp__gte: _7days_ago} })
     const forwards7d_task = GET('forwards', {data: {forward_date__gte: _7days_ago} })
-    const failedHTLCs_task = GET('failedhtlcs', {data: {wire_failure__lt: 99, limit:10} })
     const payments_task = GET('payments', {data: {creation_date__gte: _7days_ago, status: 2} })
     const closures_task = GET('closures', {data: {close_height__gte: ({{node_info.block_height}} - 1008) } })
     
@@ -934,6 +942,19 @@
     update_summary(payments7d, onchain_task, closures_task, activeSum, inactiveSum, privateSum, forwards_summary, inv_rev_task)
     build_routed(forwards7d)
     build_payments(payments7d)
+    async function auto_refresh(){
+      while(document.hidden) {
+        await sleep(500)
+      }
+      
+      await buildMain()
+    }
+    setTimeout(async () => await auto_refresh(), 21000)
+  }
+  document.addEventListener('DOMContentLoaded', async () => { 
+    await buildMain()
+    const invoices_task = GET('invoices', {data: {state__lt: 2, limit: 10} })
+    const failedHTLCs_task = GET('failedhtlcs', {data: {wire_failure__lt: 99, limit:10} })
     build_invoices((await invoices_task).results)
     build_failedHTLC((await failedHTLCs_task).results)
   })

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -909,35 +909,11 @@
     
     return node_info
   }
-  function build_pending_open(channels){
-    if(!addTitle('Pending Open', channels)){
+  function build(id, template_arg, channels){
+    if(!addTitle(id, channels)){
       return;
     }
-    const table = byId('pending_open'), template = use(pending_open_template)
-    table.innerHTML = null
-    channels.forEach(ch => table.append(template.render(ch)))
-  }
-  function build_pending_closed(channels){
-    if(!addTitle('Pending Closed', channels)){
-      return;
-    }
-    const table = byId('pending_closed'), template = use(pending_closed_template)
-    table.innerHTML = null
-    channels.forEach(ch => table.append(template.render(ch)))
-  }
-  function build_pending_fclosed(channels){
-    if(!addTitle('Pending Force Closed', channels)){
-      return;
-    }
-    const table = byId('pending_force_closed'), template = use(pending_fclosed_template)
-    table.innerHTML = null
-    channels.forEach(ch => table.append(template.render(ch)))
-  }
-  function build_wating_close(channels){
-    if(!addTitle('Waiting For Close', channels)){
-      return;
-    }
-    const table = byId('waiting_for_close'), template = use(pending_closed_template)
+    const table = byId(id.split(" ").join("_").toLowerCase()), template = use(template_arg)
     table.innerHTML = null
     channels.forEach(ch => table.append(template.render(ch)))
   }
@@ -969,17 +945,16 @@
     let [forwards_sum, forwards_summary] = process_forwards(forwards7d)
     let [activeSum, privateSum, inactiveSum] = [build_active(active, forwards_sum), build_private(private), build_inactive(inactive)]
     update_summary(node_info, payments7d, onchain_task, closures_task, activeSum, inactiveSum, privateSum, forwards_summary, inv_rev_task)
-    build_pending_open(node_info.pending_open||[])
-    build_pending_closed(node_info.pending_closed||[])
-    build_wating_close(node_info.waiting_for_close||[])
-    build_pending_fclosed(node_info.pending_force_closed||[])
+    build('Pending Open', pending_open_template, node_info.pending_open||[])
+    build('Pending Closed', pending_closed_template, node_info.pending_closed||[])
+    build('Waiting For Close', pending_closed_template, node_info.waiting_for_close||[])
+    build('Pending Force Closed', pending_fclosed_template, node_info.pending_force_closed||[])
     build_routed(forwards7d)
     build_payments(payments7d)
     async function auto_refresh(){
       while(document.hidden) {
         await sleep(500)
       }
-      
       await buildMain()
     }
     setTimeout(async () => await auto_refresh(), 21000)

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -84,12 +84,12 @@
   <table class="w3-col w3-small w3-table-all w3-centered w3-hoverable" style="min-width:1000px;width:75%">
     <thead>
       <tr>
-        <th class="w3-border-bottom w3-border-right"><a href="/balances" target="_blank">Balance</a>: <span id="total_balance">{{total_balance}}</span></th>
-        <th class="w3-border-bottom w3-border-right">Onchain: {{ balances.total_balance|intcomma }}</th>
-        <th colspan="2" class="w3-border-bottom w3-border-right">Confirmed: {{ balances.confirmed_balance|intcomma }}</th>
-        <th class="w3-border-bottom w3-border-right">Unconfirmed: {{ balances.unconfirmed_balance|intcomma }}</th>
-        <th class="w3-border-bottom w3-border-right">Limbo: {{ limbo_balance|intcomma }} </th>
-        <th class="w3-border-bottom w3-border-right"><a href="/pending_htlcs" target="_blank">Pending HTLCs</a>: <span id="pending_htlcs">0</span>{{ pending_htlc_count }}</th>
+        <th class="w3-border-bottom w3-border-right"><a href="/balances" target="_blank">Balance</a>: <span id="total_balance">0</span></th>
+        <th id="onChain" class="w3-border-bottom w3-border-right">Onchain: 0</th>
+        <th id="confirmed" colspan="2" class="w3-border-bottom w3-border-right">Confirmed: 0</th>
+        <th id="unconfirmed" class="w3-border-bottom w3-border-right">Unconfirmed: 0</th>
+        <th id="limbo" class="w3-border-bottom w3-border-right">Limbo: 0</th>
+        <th id="pending_htlcs" class="w3-border-bottom w3-border-right">Pending HTLCs: 0</th>
         <th class="w3-border-bottom">
           <form method="post" action="/newaddress/">
             {% csrf_token %}
@@ -804,7 +804,7 @@
     const public = merge(active, inactive), sum = merge(public, private)
     const [total_outbound, total_bal] = [sum.outbound || 1, byId('total_balance')]
     byId('liq_ratio').innerHTML = (public.inbound*100/public.outbound||1).intcomma()+'%'
-    total_bal.innerHTML = ({{total_balance}} + sum.outbound).intcomma()
+    total_bal.innerHTML = (total_bal.innerHTML.toInt() + sum.outbound).intcomma()
 
     for(d of [1,7]){ //build 1 & 7 days table statistics
       const earned = forwards_summary[`earned${d}d`]+offChain[`d${d}`].inv_rev, routed = {'amt':forwards_summary[`o${d}d`],'count':forwards_summary[`o${d}dc`]}, chaincosts = chainCosts[`d${d}`], offchain = offChain[`d${d}`], costs = chaincosts + offchain.fee
@@ -922,19 +922,13 @@
     return [forwards_sum, forwards_summary]
   }
   
-  async function buildMain() {
-    const inv_rev_task = GET('invoices', {data: {state: 1, is_revenue: true, settle_date__gte: _7days_ago}})
-    const onchain_task = GET('onchain', {data: {time_stamp__gte: _7days_ago} })
-    const forwards7d_task = GET('forwards', {data: {forward_date__gte: _7days_ago} })
-    const payments_task = GET('payments', {data: {creation_date__gte: _7days_ago, status: 2} })
-    const closures_task = GET('closures', {data: {close_height__gte: ({{node_info.block_height}} - 1008) } })
-    const node_info = await GET('node_info', {data: {}})
-    console.log(node_info)
+  function buildMainStats(node_info) {
     const lnd = byId('lnd')
     lnd.classList.remove('w3-red')
     lnd.classList.remove('w3-green')
     lnd.classList.toggle('w3-red', !node_info.synced_to_graph)
     lnd.classList.toggle('w3-green', node_info.synced_to_graph)
+    
     const timechain = byId('timechain')
     timechain.classList.remove('w3-border-red')
     timechain.classList.remove('w3-border-green')
@@ -947,6 +941,22 @@
     byId('total_channels').innerHTML = node_info.num_active_channels + node_info.num_inactive_channels
     byId('peers').innerHTML = `<a href="/peers" target="_blank">Peers</a>: ${node_info.num_peers}`
     if(node_info.db_size > 0) byId('dbSize').innerHTML = `DB Size: ${node_info.db_size} GB`
+
+    byId('total_balance').innerHTML = node_info.balance.total.intcomma()
+    byId('onChain').innerHTML = `Onchain: ${node_info.balance.onchain.intcomma()}`
+    byId('confirmed').innerHTML = `Confirmed: ${node_info.balance.confirmed.intcomma()}`
+    byId('unconfirmed').innerHTML = `Unconfirmed: ${node_info.balance.unconfirmed.intcomma()}`
+    byId('limbo').innerHTML = `Limbo: ${node_info.balance.limbo.intcomma()}`
+    
+    return node_info
+  }
+  async function buildMain() {
+    const inv_rev_task = GET('invoices', {data: {state: 1, is_revenue: true, settle_date__gte: _7days_ago}})
+    const onchain_task = GET('onchain', {data: {time_stamp__gte: _7days_ago} })
+    const forwards7d_task = GET('forwards', {data: {forward_date__gte: _7days_ago} })
+    const payments_task = GET('payments', {data: {creation_date__gte: _7days_ago, status: 2} })
+    const closures_task = GET('closures', {data: {close_height__gte: ({{node_info.block_height}} - 1008) } })
+    const node_info = buildMainStats(await GET('node_info', {data: {}}))
 
     let [updates, pending_htlcs, active, inactive, private] = [0,0,[],[],[]]
     for (ch of (await GET('channels', {data: {is_open:true} })).results){ //basic setup
@@ -962,7 +972,7 @@
     }
 
     byId("updates").innerHTML = updates.intcomma()
-    byId("pending_htlcs").innerHTML = pending_htlcs.intcomma()
+    byId("pending_htlcs").innerHTML = `<a href="/pending_htlcs" target="_blank">Pending HTLCs</a>: ${pending_htlcs.intcomma()}`
 
     let [forwards7d, payments7d] = [(await forwards7d_task).results, (await payments_task).results]
     let [forwards_sum, forwards_summary] = process_forwards(forwards7d)

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -262,35 +262,23 @@
     <tbody id="pending_closed"></tbody>
   </table>
 </div>
-{% if pending_force_closed %}
-<div class="w3-container w3-padding-small">
-  <h2>Pending Force Close Channels</h2>
+<div id="pending_force_closed_container" class="w3-container w3-padding-small">
   <table class="w3-table-all w3-centered w3-hoverable">
-    <tr>
-      <th>Channel ID</th>
-      <th>Peer Alias</th>
-      <th>Capacity</th>
-      <th>Local Balance</th>
-      <th>Remote Balance</th>
-      <th>Balance In Limbo</th>
-      <th>Maturity</th>
-      <th width=20%>Closing TX</th>
-    </tr>
-    {% for channel in pending_force_closed %}
-    <tr>
-      <td title="{{ channel.channel_point }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
-      <td title="{{ channel.remote_node_pub }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_node_pub }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_node_pub|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
-      <td>{{ channel.capacity|intcomma }}</td>
-      <td>{{ channel.local_balance|intcomma }}</td>
-      <td>{{ channel.remote_balance|intcomma }}</td>
-      <td>{{ channel.limbo_balance|intcomma }}</td>
-      <td title="Blocks: {{ channel.blocks_til_maturity|intcomma }}">{{ channel.maturity_datetime|naturaltime }}</td>
-      <td><a href='{{ network_links }}/{{ network }}tx/{{ channel.closing_txid }}' target="_blank">{{ channel.closing_txid }}</a></td>
-    </tr>
-    {% endfor %}
+    <thead>
+      <tr>
+        <th>Channel ID</th>
+        <th>Peer Alias</th>
+        <th>Capacity</th>
+        <th>Local Balance</th>
+        <th>Remote Balance</th>
+        <th>Balance In Limbo</th>
+        <th>Maturity</th>
+        <th width=20%>Closing TX</th>
+      </tr>
+    </thead>
+    <tbody id="pending_force_closed"></tbody>
   </table>
 </div>
-{% endif %}
 {% if waiting_for_close %}
 <div class="w3-container w3-padding-small">
   <h2>Channels Waiting To Close</h2>
@@ -627,8 +615,11 @@
     "local_commit" : ch => ({innerHTML: ch.local_commit_fee_sat.intcomma() }),
     "closing_tx" : ch => ({innerHTML: `<a href='{{ network_links }}/{{ network }}tx/${ch.closing_txid}' target="_blank">${ch.closing_txid}</a>`}),
   })
+  const pending_fclosed_template = Object.assign({}, pending_closed_template)
+  pending_fclosed_template["local_commit"] = ch => ({innerHTML: adjustTZ(ch.maturity_datetime), title: ch.blocks_til_maturity.intcomma() })
+
   function addTitle(id, results, title = null){
-    const container = byId(id.toLowerCase().replace(" ", "_") + '_container')
+    const container = byId(id.split(" ").join("_").toLowerCase() + '_container')
     if (results.length == 0) {
       container.style.display = 'none'
       return false
@@ -946,6 +937,14 @@
     table.innerHTML = null
     channels.forEach(ch => table.append(template.render(ch)))
   }
+  function build_pending_fclosed(channels){
+    if(!addTitle('Pending Force Closed', channels)){
+      return;
+    }
+    const table = byId('pending_force_closed'), template = use(pending_fclosed_template)
+    table.innerHTML = null
+    channels.forEach(ch => table.append(template.render(ch)))
+  }
   async function buildMain() {
     const inv_rev_task = GET('invoices', {data: {state: 1, is_revenue: true, settle_date__gte: _7days_ago}})
     const onchain_task = GET('onchain', {data: {time_stamp__gte: _7days_ago} })
@@ -976,6 +975,7 @@
     update_summary(payments7d, onchain_task, closures_task, activeSum, inactiveSum, privateSum, forwards_summary, inv_rev_task)
     build_pending_open(node_info.pending_open||[])
     build_pending_closed(node_info.pending_closed||[])
+    build_pending_fclosed(node_info.pending_force_closed||[])
     build_routed(forwards7d)
     build_payments(payments7d)
     async function auto_refresh(){

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -245,35 +245,23 @@
     <tbody id="pending_open"></tbody>
   </table>
 </div>
-{% if pending_closed %}
-<div class="w3-container w3-padding-small">
-  <h2>Pending Close Channels</h2>
+<div id="pending_closed_container" class="w3-container w3-padding-small">
   <table class="w3-table-all w3-centered w3-hoverable">
-    <tr>
-      <th>Channel ID</th>
-      <th>Peer Alias</th>
-      <th>Capacity</th>
-      <th>Local Balance</th>
-      <th>Remote Balance</th>
-      <th>Balance In Limbo</th>
-      <th>Local Commit Fee</th>
-      <th width=20%>Closing TX</th>
-    </tr>
-    {% for channel in pending_closed %}
-    <tr>
-      <td title="{{ channel.channel_point }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
-      <td title="{{ channel.remote_node_pub }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_node_pub }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_node_pub|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
-      <td>{{ channel.capacity|intcomma }}</td>
-      <td>{{ channel.local_balance|intcomma }}</td>
-      <td>{{ channel.remote_balance|intcomma }}</td>
-      <td>{{ channel.limbo_balance|intcomma }}</td>
-      <td>{{ channel.local_commit_fee_sat|intcomma }}</td>
-      <td><a href='{{ network_links }}/{{ network }}tx/{{ channel.closing_txid }}' target="_blank">{{ channel.closing_txid }}</a></td>
-    </tr>
-    {% endfor %}
+    <thead>
+      <tr>
+        <th>Channel ID</th>
+        <th>Peer Alias</th>
+        <th>Capacity</th>
+        <th>Local Balance</th>
+        <th>Remote Balance</th>
+        <th>Balance In Limbo</th>
+        <th>Local Commit Fee</th>
+        <th width=20%>Closing TX</th>
+      </tr>
+    </thead>
+    <tbody id="pending_closed"></tbody>
   </table>
 </div>
-{% endif %}
 {% if pending_force_closed %}
 <div class="w3-container w3-padding-small">
   <h2>Pending Force Close Channels</h2>
@@ -628,6 +616,17 @@
       <input type="hidden" name="target" value="0">
     </form>`, style: {backgroundColor: !ch.auto_rebalance ? 'rgba(248,81,73,0.15)' : 'rgba(46,160,67,0.15)'} }),
   }
+
+  let {capacity, local_balance, remote_balance} = pending_open_template
+  const pending_closed_template = Object.assign({}, {
+    "channel_id" : ch => ({innerHTML: `<a href="/channel?=${ch.chan_id}" target="_blank">${ch.short_chan_id}</a>`, title: ch.channel_point}),
+    "peer_alias" : ch => ({innerHTML: `<a href="{{ graph_links }}/{{ network }}node/${ch.remote_node_pub}" target="_blank">${ch.alias == '' ? ch.remote_node_pub.substr(0,12) : ch.alias }</a>`, title: ch.remote_node_pub}) 
+  }, {capacity, local_balance, remote_balance },
+  {
+    "limbo_bal" : ch => ({innerHTML: ch.limbo_balance.intcomma() }),
+    "local_commit" : ch => ({innerHTML: ch.local_commit_fee_sat.intcomma() }),
+    "closing_tx" : ch => ({innerHTML: `<a href='{{ network_links }}/{{ network }}tx/${ch.closing_txid}' target="_blank">${ch.closing_txid}</a>`}),
+  })
   function addTitle(id, results, title = null){
     const container = byId(id.toLowerCase().replace(" ", "_") + '_container')
     if (results.length == 0) {
@@ -939,6 +938,14 @@
     table.innerHTML = null
     channels.forEach(ch => table.append(template.render(ch)))
   }
+  function build_pending_closed(channels){
+    if(!addTitle('Pending Closed', channels)){
+      return;
+    }
+    const table = byId('pending_closed'), template = use(pending_closed_template)
+    table.innerHTML = null
+    channels.forEach(ch => table.append(template.render(ch)))
+  }
   async function buildMain() {
     const inv_rev_task = GET('invoices', {data: {state: 1, is_revenue: true, settle_date__gte: _7days_ago}})
     const onchain_task = GET('onchain', {data: {time_stamp__gte: _7days_ago} })
@@ -968,6 +975,7 @@
     let [activeSum, privateSum, inactiveSum] = [build_active(active, forwards_sum), build_private(private), build_inactive(inactive)]
     update_summary(payments7d, onchain_task, closures_task, activeSum, inactiveSum, privateSum, forwards_summary, inv_rev_task)
     build_pending_open(node_info.pending_open||[])
+    build_pending_closed(node_info.pending_closed||[])
     build_routed(forwards7d)
     build_payments(payments7d)
     async function auto_refresh(){

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -279,37 +279,25 @@
     <tbody id="pending_force_closed"></tbody>
   </table>
 </div>
-{% if waiting_for_close %}
-<div class="w3-container w3-padding-small">
-  <h2>Channels Waiting To Close</h2>
+<div id="waiting_for_close_container" class="w3-container w3-padding-small">
   <table class="w3-table-all w3-centered w3-hoverable">
-    <tr>
-      <th>Channel ID</th>
-      <th>Peer Alias</th>
-      <th>Capacity</th>
-      <th>Local Balance</th>
-      <th>Remote Balance</th>
-      <th>Balance In Limbo</th>
-      <th>Local Commit Fee</th>
-      <th width=20%>Closing TX</th>
-    </tr>
-    {% for channel in waiting_for_close %}
-    <tr>
-      <td title="{{ channel.channel_point }}"><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.short_chan_id }}</a></td>
-      <td title="{{ channel.remote_node_pub }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_node_pub }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_node_pub|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
-      <td>{{ channel.capacity|intcomma }}</td>
-      <td>{{ channel.local_balance|intcomma }}</td>
-      <td>{{ channel.remote_balance|intcomma }}</td>
-      <td>{{ channel.limbo_balance|intcomma }}</td>
-      <td>{{ channel.local_commit_fee_sat|intcomma }}</td>
-      <td><a href='{{ network_links }}/{{ network }}tx/{{ channel.closing_txid }}' target="_blank">{{ channel.closing_txid }}</a></td>
-    </tr>
-    {% endfor %}
+    <thead>
+      <tr>
+        <th>Channel ID</th>
+        <th>Peer Alias</th>
+        <th>Capacity</th>
+        <th>Local Balance</th>
+        <th>Remote Balance</th>
+        <th>Balance In Limbo</th>
+        <th>Local Commit Fee</th>
+        <th width=20%>Closing TX</th>
+      </tr>
+    </thead>
+    <tbody id="waiting_for_close"></tbody>
   </table>
 </div>
-{% endif %}
 <div id="routed_container" class="w3-container w3-padding-small">
-  <table  id="forwardsTable" class="w3-table-all w3-centered w3-hoverable">
+  <table id="forwardsTable" class="w3-table-all w3-centered w3-hoverable">
     <thead>
       <tr>
         <th>Timestamp</th>
@@ -945,6 +933,14 @@
     table.innerHTML = null
     channels.forEach(ch => table.append(template.render(ch)))
   }
+  function build_wating_close(channels){
+    if(!addTitle('Waiting For Close', channels)){
+      return;
+    }
+    const table = byId('waiting_for_close'), template = use(pending_closed_template)
+    table.innerHTML = null
+    channels.forEach(ch => table.append(template.render(ch)))
+  }
   async function buildMain() {
     const inv_rev_task = GET('invoices', {data: {state: 1, is_revenue: true, settle_date__gte: _7days_ago}})
     const onchain_task = GET('onchain', {data: {time_stamp__gte: _7days_ago} })
@@ -975,6 +971,7 @@
     update_summary(payments7d, onchain_task, closures_task, activeSum, inactiveSum, privateSum, forwards_summary, inv_rev_task)
     build_pending_open(node_info.pending_open||[])
     build_pending_closed(node_info.pending_closed||[])
+    build_wating_close(node_info.waiting_for_close||[])
     build_pending_fclosed(node_info.pending_force_closed||[])
     build_routed(forwards7d)
     build_payments(payments7d)

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -222,121 +222,29 @@
     <tbody id="private_channels"></tbody>
   </table>
 </div>
-{% if pending_open %}
-<div class="w3-container w3-padding-small">
-  <h2>Pending Open Channels</h2>
+<div id="pending_open_container" class="w3-container w3-padding-small">
   <table class="w3-table-all w3-centered w3-hoverable">
-    <tr>
-      <th>Peer Alias</th>
-      <th width=20%>Channel Point</th>
-      <th>Capacity</th>
-      <th>Local Balance</th>
-      <th>Remote Balance</th>
-      <th>AF</th>
-      <th>Fee Rate</th>
-      <th>Base Fee</th>
-      <th>CLTV</th>
-      <th>Amt</th>
-      <th>Max Cost%</th>
-      <th>oTarget%</th>
-      <th>iTarget%</th>
-      <th>AR</th>
-    </tr>
-    {% for channel in pending_open %}
-    <tr>
-      <td title="{{ channel.remote_node_pub }}"><a href="{{ graph_links }}/{{ network }}node/{{ channel.remote_node_pub }}" target="_blank">{% if channel.alias == '' %}{{ channel.remote_node_pub|slice:":12" }}{% else %}{{ channel.alias }}{% endif %}</a></td>
-      <td><a href='{{ network_links }}/{{ network }}tx/{{ channel.funding_txid }}' target="_blank">{{ channel.channel_point }}</a></td>
-      <td title="Commit Fee: {{ channel.commit_fee }}">{{ channel.capacity|intcomma }}</td>
-      <td>{{ channel.local_balance|intcomma }}</td>
-      <td>{{ channel.remote_balance|intcomma }}</td>
-      <td {% if channel.auto_fees == False %}style="background-color: rgba(46,160,67,0.15);"{% else %}style="background-color: rgba(248,81,73,0.15)"{% endif %}>
-        <form action="/update_pending/" method="post">
-          {% csrf_token %}
-          <input type="submit" value="{% if channel.auto_fees == True %}Disable{% else %}Enable{% endif %}">
-          <input type="hidden" name="funding_txid" value="{{ channel.funding_txid }}">
-          <input type="hidden" name="output_index" value="{{ channel.output_index }}">
-          <input type="hidden" name="update_target" value="8">
-          <input type="hidden" name="target" value="0">
-        </form>
-      </td>
-      <td>
-        <form action="/update_pending/" method="post">
-          {% csrf_token %}
-          <input style="text-align:center" id="target" type="number" min="0" max="100000" name="target" value="{{ channel.local_fee_rate }}">
-          <input type="hidden" name="funding_txid" value="{{ channel.funding_txid }}">
-          <input type="hidden" name="output_index" value="{{ channel.output_index }}">
-          <input type="hidden" name="update_target" value="1">
-        </form>
-      </td>
-      <td>
-        <form action="/update_pending/" method="post">
-          {% csrf_token %}
-          <input style="text-align:center" id="target" type="number" min="0" max="100000" name="target" value="{{ channel.local_base_fee }}">
-          <input type="hidden" name="funding_txid" value="{{ channel.funding_txid }}">
-          <input type="hidden" name="output_index" value="{{ channel.output_index }}">
-          <input type="hidden" name="update_target" value="0">
-        </form>
-      </td>
-      <td>
-        <form action="/update_pending/" method="post">
-          {% csrf_token %}
-          <input style="text-align:center" id="target" type="number" min="18" max="1000" name="target" value="{{ channel.local_cltv }}">
-          <input type="hidden" name="funding_txid" value="{{ channel.funding_txid }}">
-          <input type="hidden" name="output_index" value="{{ channel.output_index }}">
-          <input type="hidden" name="update_target" value="9">
-        </form>
-      </td>
-      <td>
-        <form action="/update_pending/" method="post">
-          {% csrf_token %}
-          <input style="text-align:center" id="target" type="number" min="1" max="100000000" name="target" value="{{ channel.ar_amt_target }}">
-          <input type="hidden" name="funding_txid" value="{{ channel.funding_txid }}">
-          <input type="hidden" name="output_index" value="{{ channel.output_index }}">
-          <input type="hidden" name="update_target" value="2">
-        </form>
-      </td>
-      <td>
-        <form action="/update_pending/" method="post">
-          {% csrf_token %}
-          <input style="text-align:center" id="target" type="number" min="1" max="100" name="target" value="{{ channel.ar_max_cost }}">
-          <input type="hidden" name="funding_txid" value="{{ channel.funding_txid }}">
-          <input type="hidden" name="output_index" value="{{ channel.output_index }}">
-          <input type="hidden" name="update_target" value="6">
-        </form>
-      </td>
-      <td style="background-color: {% if channel.auto_rebalance == False %}rgba(248,81,73,0.15){% else %}rgba(46,160,67,0.15){% endif %}">
-        <form action="/update_pending/" method="post">
-          {% csrf_token %}
-          <input style="text-align:center" id="target" type="number" min="1" max="100" name="target" value="{{ channel.ar_out_target }}">
-          <input type="hidden" name="funding_txid" value="{{ channel.funding_txid }}">
-          <input type="hidden" name="output_index" value="{{ channel.output_index }}">
-          <input type="hidden" name="update_target" value="4">
-        </form>
-      </td>
-      <td style="background-color: {% if channel.auto_rebalance == True %}rgba(46,160,67,0.15){% else %}rgba(248,81,73,0.15){% endif %}">
-        <form action="/update_pending/" method="post">
-          {% csrf_token %}
-          <input style="text-align:center" id="target" type="number" min="1" max="100" name="target" value="{{ channel.ar_in_target }}">
-          <input type="hidden" name="funding_txid" value="{{ channel.funding_txid }}">
-          <input type="hidden" name="output_index" value="{{ channel.output_index }}">
-          <input type="hidden" name="update_target" value="3">
-        </form>
-      </td>
-      <td style="background-color: {% if channel.auto_rebalance == True %}rgba(46,160,67,0.15){% else %}rgba(248,81,73,0.15){% endif %}">
-        <form action="/update_pending/" method="post">
-          {% csrf_token %}
-          <input type="submit" value="{% if channel.auto_rebalance == True %}Disable{% else %}Enable{% endif %}">
-          <input type="hidden" name="funding_txid" value="{{ channel.funding_txid }}">
-          <input type="hidden" name="output_index" value="{{ channel.output_index }}">
-          <input type="hidden" name="update_target" value="5">
-          <input type="hidden" name="target" value="0">
-        </form>
-      </td>
-    </tr>
-    {% endfor %}
+    <thead>
+      <tr>
+        <th>Peer Alias</th>
+        <th width=20%>Channel Point</th>
+        <th>Capacity</th>
+        <th>Local Balance</th>
+        <th>Remote Balance</th>
+        <th>AF</th>
+        <th>Fee Rate</th>
+        <th>Base Fee</th>
+        <th>CLTV</th>
+        <th>Amt</th>
+        <th>Max Cost%</th>
+        <th>oTarget%</th>
+        <th>iTarget%</th>
+        <th>AR</th>
+      </tr>
+    </thead>
+    <tbody id="pending_open"></tbody>
   </table>
 </div>
-{% endif %}
 {% if pending_closed %}
 <div class="w3-container w3-padding-small">
   <h2>Pending Close Channels</h2>
@@ -648,12 +556,85 @@
     "keysend_preimage": i => ({innerHTML: keysend_preimage(i).innerHTML, title: i.message }),
     }
   )
+  const pending_open_template = {
+    "alias": ch => ({innerHTML: `<a href="{{graph_links}}/{{network}}node/${ch.remote_node_pub}" target="_blank">${ch.alias == '' ? ch.remote_node_pub.substr(0,12) : ch.alias }</a>`, title: ch.remote_node_pub}),
+    "channel_point": ch => ({innerHTML: `<a href='{{ network_links }}/{{ network }}tx/${ch.funding_txid}' target="_blank">${ch.channel_point}</a>`}),
+    "capacity": ch => ({innerHTML: ch.capacity.intcomma(), title: `Commit Fee: ${ch.commit_fee}`}),
+    "local_balance": ch => ({innerHTML: ch.local_balance.intcomma()}),
+    "remote_balance": ch => ({innerHTML: ch.remote_balance.intcomma()}),
+    "af": ch => ({innerHTML: `<form action="/update_pending/" method="post">
+      {% csrf_token %}
+      <input type="submit" value="${ch.auto_fees ? 'Dis' : 'En'}able">
+      <input type="hidden" name="funding_txid" value="${ch.funding_txid}">
+      <input type="hidden" name="output_index" value="${ch.output_index}">
+      <input type="hidden" name="update_target" value="8">
+      <input type="hidden" name="target" value="0">
+    </form>`, style: {backgroundColor: ch.auto_fees? 'rgba(46,160,67,0.15)' : 'rgba(248,81,73,0.15)'} }),
+    "fee_rate": ch => ({innerHTML: `<form action="/update_pending/" method="post">
+      {% csrf_token %}
+      <input style="text-align:center" id="target" type="number" min="0" max="100000" name="target" value="${ch.local_fee_rate}">
+      <input type="hidden" name="funding_txid" value="${ch.funding_txid}">
+      <input type="hidden" name="output_index" value="${ch.output_index}">
+      <input type="hidden" name="update_target" value="1">
+    </form>`}),
+    "base_fee": ch => ({innerHTML: `<form action="/update_pending/" method="post">
+      {% csrf_token %}
+      <input style="text-align:center" id="target" type="number" min="0" max="100000" name="target" value="${ch.local_base_fee}">
+      <input type="hidden" name="funding_txid" value="${ch.funding_txid}">
+      <input type="hidden" name="output_index" value="${ch.output_index}">
+      <input type="hidden" name="update_target" value="0">
+    </form>`}),
+    "cltv": ch => ({innerHTML: `<form action="/update_pending/" method="post">
+      {% csrf_token %}
+      <input style="text-align:center" id="target" type="number" min="18" max="1000" name="target" value="${ch.local_cltv}">
+      <input type="hidden" name="funding_txid" value="${ch.funding_txid}">
+      <input type="hidden" name="output_index" value="${ch.output_index}">
+      <input type="hidden" name="update_target" value="9">
+    </form>`}),
+    "amt": ch => ({innerHTML: `<form action="/update_pending/" method="post">
+      {% csrf_token %}
+      <input style="text-align:center" id="target" type="number" min="1" max="100000000" name="target" value="${ch.ar_amt_target}">
+      <input type="hidden" name="funding_txid" value="${ch.funding_txid}">
+      <input type="hidden" name="output_index" value="${ch.output_index}">
+      <input type="hidden" name="update_target" value="2">
+    </form>`}),
+    "max_cost": ch => ({innerHTML: `<form action="/update_pending/" method="post">
+      {% csrf_token %}
+      <input style="text-align:center" id="target" type="number" min="1" max="100" name="target" value="${ch.ar_max_cost}">
+      <input type="hidden" name="funding_txid" value="${ch.funding_txid}">
+      <input type="hidden" name="output_index" value="${ch.output_index}">
+      <input type="hidden" name="update_target" value="6">
+    </form>`}),
+    "otarget": ch => ({innerHTML: `<form action="/update_pending/" method="post">
+      {% csrf_token %}
+      <input style="text-align:center" id="target" type="number" min="1" max="100" name="target" value="${ch.ar_out_target}">
+      <input type="hidden" name="funding_txid" value="${ch.funding_txid}">
+      <input type="hidden" name="output_index" value="${ch.output_index}">
+      <input type="hidden" name="update_target" value="4">
+    </form>`, style: {backgroundColor: !ch.auto_rebalance ? 'rgba(248,81,73,0.15)' : 'rgba(46,160,67,0.15)'} }),
+    "itarget": ch => ({innerHTML: `<form action="/update_pending/" method="post">
+      {% csrf_token %}
+      <input style="text-align:center" id="target" type="number" min="1" max="100" name="target" value="${ch.ar_in_target}">
+      <input type="hidden" name="funding_txid" value="${ch.funding_txid}">
+      <input type="hidden" name="output_index" value="${ch.output_index}">
+      <input type="hidden" name="update_target" value="3">
+    </form>`, style: {backgroundColor: !ch.auto_rebalance ? 'rgba(248,81,73,0.15)' : 'rgba(46,160,67,0.15)'} }),
+    "ar": ch => ({innerHTML: `<form action="/update_pending/" method="post">
+      {% csrf_token %}
+      <input type="submit" value="${ch.auto_rebalance ? 'Dis': 'En'}able">
+      <input type="hidden" name="funding_txid" value="${ch.funding_txid}">
+      <input type="hidden" name="output_index" value="${ch.output_index}">
+      <input type="hidden" name="update_target" value="5">
+      <input type="hidden" name="target" value="0">
+    </form>`, style: {backgroundColor: !ch.auto_rebalance ? 'rgba(248,81,73,0.15)' : 'rgba(46,160,67,0.15)'} }),
+  }
   function addTitle(id, results, title = null){
     const container = byId(id.toLowerCase().replace(" ", "_") + '_container')
     if (results.length == 0) {
-      container?.remove()
+      container.style.display = 'none'
       return false
     }
+    container.style.display = 'block'
     if (container.querySelector('h2')) container.querySelector('h2').innerHTML = null
     container.insertAdjacentHTML('afterbegin', `<h2>${title || id}</h2>`)
     return true
@@ -950,6 +931,14 @@
     
     return node_info
   }
+  function build_pending_open(channels){
+    if(!addTitle('Pending Open', channels)){
+      return;
+    }
+    const table = byId('pending_open'), template = use(pending_open_template)
+    table.innerHTML = null
+    channels.forEach(ch => table.append(template.render(ch)))
+  }
   async function buildMain() {
     const inv_rev_task = GET('invoices', {data: {state: 1, is_revenue: true, settle_date__gte: _7days_ago}})
     const onchain_task = GET('onchain', {data: {time_stamp__gte: _7days_ago} })
@@ -978,6 +967,7 @@
     let [forwards_sum, forwards_summary] = process_forwards(forwards7d)
     let [activeSum, privateSum, inactiveSum] = [build_active(active, forwards_sum), build_private(private), build_inactive(inactive)]
     update_summary(payments7d, onchain_task, closures_task, activeSum, inactiveSum, privateSum, forwards_summary, inv_rev_task)
+    build_pending_open(node_info.pending_open||[])
     build_routed(forwards7d)
     build_payments(payments7d)
     async function auto_refresh(){

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -957,7 +957,7 @@
       }
       await buildMain()
     }
-    setTimeout(async () => await auto_refresh(), 21000)
+    setTimeout(auto_refresh, 21000)
   }
   document.addEventListener('DOMContentLoaded', async () => { 
     await buildMain()

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -25,14 +25,14 @@
       <a style="margin-left:6px;" href="{{ graph_links }}/{{ network }}node/{{ node_info.identity_pubkey }}" target="_blank">{{ node_info.alias }}</a> | {{ node_info.identity_pubkey }}
     </h3>
   <h6>
-    <span class="w3-tag w3-round w3-{% if node_info.synced_to_graph %}green{% else %}red{% endif %}" title="{{ node_info.version }}">LND</span>
-    <span style="padding:1.5px 8px;" class="w3-round w3-border w3-border-{% if node_info.synced_to_chain %}green{% else %}red{% endif %}" title="Chain {% if not node_info.synced_to_chain %}Not {% endif %}Synced">{% for info in node_info.chains %}{{ info }}{% endfor %} | {{ node_info.block_height }} #{{ node_info.block_hash }}</span>
+    <span id="lnd" class="w3-tag w3-round" title="{{ node_info.version }}">LND</span>
+    <span id="timechain" style="padding:1.5px 8px;" class="w3-round w3-border">---</span>
   </h6>
   <h6>
     <span style="padding:1.5px 8px;" class="w3-round w3-border w3-border-grey">Public Capacity: <span id="public_capacity">0</span></span>
-    <span style="padding:1.5px 8px;" class="w3-round w3-border w3-border-grey">Active Channels: <span id="public_channels_count">{{node_info.num_active_channels}}</span> / <span id="total_channels">{{node_info.num_active_channels|add:node_info.num_inactive_channels}}</span></span>
-    <span style="padding:1.5px 8px;" class="w3-round w3-border w3-border-grey"><a href="/peers" target="_blank">Peers</a>: {{ node_info.num_peers }}</span>
-    <span style="padding:1.5px 8px;" class="w3-round w3-border w3-border-grey">DB Size: {% if db_size > 0 %}{{ db_size }} GB{% else %}---{% endif %}</span>
+    <span style="padding:1.5px 8px;" class="w3-round w3-border w3-border-grey">Active Channels: <span id="public_channels_count">0</span> / <span id="total_channels">0</span></span>
+    <span id="peers" style="padding:1.5px 8px;" class="w3-round w3-border w3-border-grey">0</span>
+    <span id="dbSize" style="padding:1.5px 8px;" class="w3-round w3-border w3-border-grey">---</span>
     <span style="padding:1.5px 8px;" class="w3-round w3-border w3-border-grey">Total States Updates: <span id="updates">---</span></span>
     <span style="padding:1.5px 8px;margin-left:4px" class="w3-round w3-border w3-border-grey"><a href="#sign">Sign a message</a></span>
   </h6>
@@ -919,7 +919,26 @@
     const forwards7d_task = GET('forwards', {data: {forward_date__gte: _7days_ago} })
     const payments_task = GET('payments', {data: {creation_date__gte: _7days_ago, status: 2} })
     const closures_task = GET('closures', {data: {close_height__gte: ({{node_info.block_height}} - 1008) } })
-    
+    const node_info = await GET('node_info', {data: {}})
+    console.log(node_info)
+    const lnd = byId('lnd')
+    lnd.classList.remove('w3-red')
+    lnd.classList.remove('w3-green')
+    lnd.classList.toggle('w3-red', !node_info.synced_to_graph)
+    lnd.classList.toggle('w3-green', node_info.synced_to_graph)
+    const timechain = byId('timechain')
+    timechain.classList.remove('w3-border-red')
+    timechain.classList.remove('w3-border-green')
+    timechain.classList.toggle('w3-border-red', !node_info.synced_to_chain)
+    timechain.classList.toggle('w3-border-green', node_info.synced_to_chain)
+    timechain.title = `Chain ${!node_info.synced_to_chain ? 'Not' : ''} Synced`
+    timechain.innerHTML = node_info.chains.join(', ') + ` | ${node_info.block.height} #${node_info.block.hash}`
+
+    byId('public_channels_count').innerHTML = node_info.num_active_channels
+    byId('total_channels').innerHTML = node_info.num_active_channels + node_info.num_inactive_channels
+    byId('peers').innerHTML = `<a href="/peers" target="_blank">Peers</a>: ${node_info.num_peers}`
+    if(node_info.db_size > 0) byId('dbSize').innerHTML = `DB Size: ${node_info.db_size} GB`
+
     let [updates, pending_htlcs, active, inactive, private] = [0,0,[],[],[]]
     for (ch of (await GET('channels', {data: {is_open:true} })).results){ //basic setup
       updates += ch.num_updates

--- a/gui/templates/rebalances_table.html
+++ b/gui/templates/rebalances_table.html
@@ -87,13 +87,7 @@
       table.innerHTML = null
       res.results.forEach(rebalance => table.append(template.render(rebalance)));
 
-      async function auto_refresh(){
-        while(document.hidden) {
-          await sleep(500)
-        }
-        await buildTable()
-      }
-      setTimeout(auto_refresh, 21000)
+      await auto_refresh(buildTable)
     }
 
     document.addEventListener('DOMContentLoaded', buildTable);

--- a/gui/templates/rebalances_table.html
+++ b/gui/templates/rebalances_table.html
@@ -75,17 +75,29 @@
         return {innerHTML: input}
       } 
     };
-    document.addEventListener('DOMContentLoaded', async () => {
+    async function buildTable(){
       const res = await GET('rebalancer', {data: {limit: '{{count}}', status: '{{status}}', payment_hash: '{{payment_hash}}', last_hop_pubkey:'{{last_hop_pubkey}}' }})
       if(res.errors) return
       if(res.results.length == 0){
-        document.getElementById("rebalances_div_{{status}}").innerHTML = `<center><h1>You dont have any rebalances yet.</h1></center>`
+        document.getElementById("rebalances_div_{{status}}").innerHTML = `<center><h1>You dont have any ${statuses['{{status}}'].toLowerCase()} rebalance request</h1></center>`
         return
       }
 
       const table = document.getElementById("rebalances_{{status}}"), template = use(transformations)
+      table.innerHTML = null
       res.results.forEach(rebalance => table.append(template.render(rebalance)));
-    });
+
+      async function auto_refresh(){
+        while(document.hidden) {
+          await sleep(500)
+        }
+        await buildTable()
+      }
+      setTimeout(auto_refresh, 21000)
+    }
+
+    document.addEventListener('DOMContentLoaded', buildTable);
+
     async function loadRebals_{{status}}(){
       const status = "{{ status }}"
       const rebalsTable = byId('rebalsTable_'+status)

--- a/gui/urls.py
+++ b/gui/urls.py
@@ -84,5 +84,6 @@ urlpatterns = [
     path('api/chart/', views.chart, name='chart'),
     path('api/chanpolicy/', views.chan_policy, name='chan-policy'),
     path('api/broadcast_tx/', views.broadcast_tx, name='broadcast-tx'),
+    path('api/node_info/', views.node_info, name='node-info'),
     path('lndg-admin/', admin.site.urls),
 ]

--- a/gui/views.py
+++ b/gui/views.py
@@ -70,117 +70,24 @@ class is_login_required(object):
 
 @is_login_required(login_required(login_url='/lndg-admin/login/?next=/'), settings.LOGIN_REQUIRED)
 def home(request):
-    if request.method == 'GET':
-        try:
-            stub = lnrpc.LightningStub(lnd_connect())
-            #Get balance and general node information
-            node_info = stub.GetInfo(ln.GetInfoRequest())
-            balances = stub.WalletBalance(ln.WalletBalanceRequest())
-            pending_channels = stub.PendingChannels(ln.PendingChannelsRequest())
-            limbo_balance = pending_channels.total_limbo_balance
-            pending_open = None
-            pending_closed = None
-            pending_force_closed = None
-            waiting_for_close = None
-            pending_open_balance = 0
-            pending_closing_balance = 0
-            if pending_channels.pending_open_channels:
-                target_resp = pending_channels.pending_open_channels
-                peers = Peers.objects.all()
-                pending_changes = PendingChannels.objects.all()
-                pending_open = []
-                inbound_setting = int(LocalSettings.objects.filter(key='AR-Inbound%')[0].value) if LocalSettings.objects.filter(key='AR-Inbound%').exists() else 100
-                outbound_setting = int(LocalSettings.objects.filter(key='AR-Outbound%')[0].value) if LocalSettings.objects.filter(key='AR-Outbound%').exists() else 75
-                amt_setting = float(LocalSettings.objects.filter(key='AR-Target%')[0].value) if LocalSettings.objects.filter(key='AR-Target%').exists() else 5
-                cost_setting = int(LocalSettings.objects.filter(key='AR-MaxCost%')[0].value) if LocalSettings.objects.filter(key='AR-MaxCost%').exists() else 65
-                auto_fees = int(LocalSettings.objects.filter(key='AF-Enabled')[0].value) if LocalSettings.objects.filter(key='AF-Enabled').exists() else 0
-                for i in range(0,len(target_resp)):
-                    item = {}
-                    pending_open_balance += target_resp[i].channel.local_balance
-                    funding_txid = target_resp[i].channel.channel_point.split(':')[0]
-                    output_index = target_resp[i].channel.channel_point.split(':')[1]
-                    updated = pending_changes.filter(funding_txid=funding_txid,output_index=output_index).exists()
-                    item['alias'] = peers.filter(pubkey=target_resp[i].channel.remote_node_pub)[0].alias if peers.filter(pubkey=target_resp[i].channel.remote_node_pub).exists() else ''
-                    item['remote_node_pub'] = target_resp[i].channel.remote_node_pub
-                    item['channel_point'] = target_resp[i].channel.channel_point
-                    item['funding_txid'] = funding_txid
-                    item['output_index'] = output_index
-                    item['capacity'] = target_resp[i].channel.capacity
-                    item['local_balance'] = target_resp[i].channel.local_balance
-                    item['remote_balance'] = target_resp[i].channel.remote_balance
-                    item['local_chan_reserve_sat'] = target_resp[i].channel.local_chan_reserve_sat
-                    item['remote_chan_reserve_sat'] = target_resp[i].channel.remote_chan_reserve_sat
-                    item['initiator'] = target_resp[i].channel.initiator
-                    item['commitment_type'] = target_resp[i].channel.commitment_type
-                    item['commit_fee'] = target_resp[i].commit_fee
-                    item['commit_weight'] = target_resp[i].commit_weight
-                    item['fee_per_kw'] = target_resp[i].fee_per_kw
-                    item['local_base_fee'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].local_base_fee if updated else ''
-                    item['local_fee_rate'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].local_fee_rate if updated else ''
-                    item['local_cltv'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].local_cltv if updated else ''
-                    item['auto_rebalance'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].auto_rebalance if updated and pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].auto_rebalance != None else False
-                    item['ar_amt_target'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].ar_amt_target if updated and pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].ar_amt_target != None else int((amt_setting/100) * target_resp[i].channel.capacity)
-                    item['ar_in_target'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].ar_in_target if updated and pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].ar_in_target != None else inbound_setting
-                    item['ar_out_target'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].ar_out_target if updated and pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].ar_out_target != None else outbound_setting
-                    item['ar_max_cost'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].ar_max_cost if updated and pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].ar_max_cost != None else cost_setting
-                    item['auto_fees'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].auto_fees if updated and pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].auto_fees != None else (False if auto_fees == 0 else True)
-                    pending_open.append(item)
-            if pending_channels.pending_closing_channels:
-                target_resp = pending_channels.pending_closing_channels
-                pending_closed = []
-                for i in range(0,len(target_resp)):
-                    pending_item = {'remote_node_pub':target_resp[i].channel.remote_node_pub,'channel_point':target_resp[i].channel.channel_point,'capacity':target_resp[i].channel.capacity,'local_balance':target_resp[i].channel.local_balance,'remote_balance':target_resp[i].channel.remote_balance,'local_chan_reserve_sat':target_resp[i].channel.local_chan_reserve_sat,
-                    'remote_chan_reserve_sat':target_resp[i].channel.remote_chan_reserve_sat,'initiator':target_resp[i].channel.initiator,'commitment_type':target_resp[i].channel.commitment_type, 'local_commit_fee_sat': target_resp[i].commitments.local_commit_fee_sat,'limbo_balance':target_resp[i].limbo_balance,'closing_txid':target_resp[i].closing_txid}
-                    pending_item.update(pending_channel_details(target_resp[i].channel.channel_point))
-                    pending_closed.append(pending_item)
-            if pending_channels.pending_force_closing_channels:
-                target_resp = pending_channels.pending_force_closing_channels
-                pending_force_closed = []
-                for i in range(0,len(target_resp)):
-                    pending_item = {'remote_node_pub':target_resp[i].channel.remote_node_pub,'channel_point':target_resp[i].channel.channel_point,'capacity':target_resp[i].channel.capacity,'local_balance':target_resp[i].channel.local_balance,'remote_balance':target_resp[i].channel.remote_balance,'initiator':target_resp[i].channel.initiator,
-                    'commitment_type':target_resp[i].channel.commitment_type,'closing_txid':target_resp[i].closing_txid,'limbo_balance':target_resp[i].limbo_balance,'maturity_height':target_resp[i].maturity_height,'blocks_til_maturity':target_resp[i].blocks_til_maturity if target_resp[i].blocks_til_maturity > 0 else find_next_block_maturity(target_resp[i]),
-                    'maturity_datetime':(datetime.now()+timedelta(minutes=(10*target_resp[i].blocks_til_maturity if target_resp[i].blocks_til_maturity > 0 else 10*find_next_block_maturity(target_resp[i]) )))}
-                    pending_item.update(pending_channel_details(target_resp[i].channel.channel_point))
-                    pending_force_closed.append(pending_item)
-            if pending_channels.waiting_close_channels:
-                target_resp = pending_channels.waiting_close_channels
-                waiting_for_close = []
-                for i in range(0,len(target_resp)):
-                    pending_closing_balance += target_resp[i].limbo_balance
-                    pending_item = {'remote_node_pub':target_resp[i].channel.remote_node_pub,'channel_point':target_resp[i].channel.channel_point,'capacity':target_resp[i].channel.capacity,'local_balance':target_resp[i].channel.local_balance,'remote_balance':target_resp[i].channel.remote_balance,'local_chan_reserve_sat':target_resp[i].channel.local_chan_reserve_sat,
-                    'remote_chan_reserve_sat':target_resp[i].channel.remote_chan_reserve_sat,'initiator':target_resp[i].channel.initiator,'commitment_type':target_resp[i].channel.commitment_type, 'local_commit_fee_sat': target_resp[i].commitments.local_commit_fee_sat, 'limbo_balance':target_resp[i].limbo_balance,'closing_txid':target_resp[i].closing_txid}
-                    pending_item.update(pending_channel_details(target_resp[i].channel.channel_point))
-                    waiting_for_close.append(pending_item)
-            limbo_balance -= pending_closing_balance
-            try:
-                db_size = round(path.getsize(path.expanduser(settings.LND_DATABASE_PATH))*0.000000001, 3)
-            except:
-                db_size = 0
-            #Build context for front-end and render page
-            context = {
-                'node_info': node_info,
-                'balances': balances,
-                'total_balance': balances.total_balance + pending_open_balance + limbo_balance,
-                'limbo_balance': limbo_balance,
-                'pending_open': pending_open,
-                'pending_closed': pending_closed,
-                'pending_force_closed': pending_force_closed,
-                'waiting_for_close': waiting_for_close,
-                'local_settings': get_local_settings('AR-'),
-                'network': 'testnet/' if settings.LND_NETWORK == 'testnet' else '',
-                'graph_links': graph_links(),
-                'network_links': network_links(),
-                'db_size': db_size,
-            }
-            return render(request, 'home.html', context)
-        except Exception as e:
-            try:
-                error = str(e.code())
-            except:
-                error = str(e)
-            return render(request, 'error.html', {'error': error})
-    else:
+    if request.method != 'GET':
         return redirect('home')
+    try:
+        stub = lnrpc.LightningStub(lnd_connect())
+        node_info = stub.GetInfo(ln.GetInfoRequest())
+    except Exception as e:
+        try:
+            error = str(e.code())
+        except:
+            error = str(e)
+        return render(request, 'error.html', {'error': error})
+    return render(request, 'home.html', {
+        'node_info': {'color': node_info.color, 'alias': node_info.alias, 'version': node_info.version, 'identity_pubkey': node_info.identity_pubkey, 'uris': node_info.uris},
+        'local_settings': get_local_settings('AR-'),
+        'network': 'testnet/' if settings.LND_NETWORK == 'testnet' else '',
+        'graph_links': graph_links(),
+        'network_links': network_links(),
+    })
 
 @is_login_required(login_required(login_url='/lndg-admin/login/?next=/'), settings.LOGIN_REQUIRED)
 def channels(request):
@@ -2296,6 +2203,116 @@ class RebalancerViewSet(viewsets.ReadOnlyModelViewSet):
             serializer.save()
             return Response(serializer.data)
         return Response(serializer.errors)
+
+
+@api_view(['GET'])
+@is_login_required(permission_classes([IsAuthenticated]), settings.LOGIN_REQUIRED)
+def node_info(request): 
+    stub = lnrpc.LightningStub(lnd_connect())
+    node_info = stub.GetInfo(ln.GetInfoRequest())
+    balances = stub.WalletBalance(ln.WalletBalanceRequest())
+    pending_channels = stub.PendingChannels(ln.PendingChannelsRequest())
+    
+    limbo_balance = pending_channels.total_limbo_balance
+    pending_open = None
+    pending_closed = None
+    pending_force_closed = None
+    waiting_for_close = None
+    pending_open_balance = 0
+    pending_closing_balance = 0
+    if pending_channels.pending_open_channels:
+        target_resp = pending_channels.pending_open_channels
+        peers = Peers.objects.all()
+        pending_changes = PendingChannels.objects.all()
+        pending_open = []
+        inbound_setting = int(LocalSettings.objects.filter(key='AR-Inbound%')[0].value) if LocalSettings.objects.filter(key='AR-Inbound%').exists() else 100
+        outbound_setting = int(LocalSettings.objects.filter(key='AR-Outbound%')[0].value) if LocalSettings.objects.filter(key='AR-Outbound%').exists() else 75
+        amt_setting = float(LocalSettings.objects.filter(key='AR-Target%')[0].value) if LocalSettings.objects.filter(key='AR-Target%').exists() else 5
+        cost_setting = int(LocalSettings.objects.filter(key='AR-MaxCost%')[0].value) if LocalSettings.objects.filter(key='AR-MaxCost%').exists() else 65
+        auto_fees = int(LocalSettings.objects.filter(key='AF-Enabled')[0].value) if LocalSettings.objects.filter(key='AF-Enabled').exists() else 0
+        for i in range(0,len(target_resp)):
+            item = {}
+            pending_open_balance += target_resp[i].channel.local_balance
+            funding_txid = target_resp[i].channel.channel_point.split(':')[0]
+            output_index = target_resp[i].channel.channel_point.split(':')[1]
+            updated = pending_changes.filter(funding_txid=funding_txid,output_index=output_index).exists()
+            item['alias'] = peers.filter(pubkey=target_resp[i].channel.remote_node_pub)[0].alias if peers.filter(pubkey=target_resp[i].channel.remote_node_pub).exists() else ''
+            item['remote_node_pub'] = target_resp[i].channel.remote_node_pub
+            item['channel_point'] = target_resp[i].channel.channel_point
+            item['funding_txid'] = funding_txid
+            item['output_index'] = output_index
+            item['capacity'] = target_resp[i].channel.capacity
+            item['local_balance'] = target_resp[i].channel.local_balance
+            item['remote_balance'] = target_resp[i].channel.remote_balance
+            item['local_chan_reserve_sat'] = target_resp[i].channel.local_chan_reserve_sat
+            item['remote_chan_reserve_sat'] = target_resp[i].channel.remote_chan_reserve_sat
+            item['initiator'] = target_resp[i].channel.initiator
+            item['commitment_type'] = target_resp[i].channel.commitment_type
+            item['commit_fee'] = target_resp[i].commit_fee
+            item['commit_weight'] = target_resp[i].commit_weight
+            item['fee_per_kw'] = target_resp[i].fee_per_kw
+            item['local_base_fee'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].local_base_fee if updated else ''
+            item['local_fee_rate'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].local_fee_rate if updated else ''
+            item['local_cltv'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].local_cltv if updated else ''
+            item['auto_rebalance'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].auto_rebalance if updated and pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].auto_rebalance != None else False
+            item['ar_amt_target'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].ar_amt_target if updated and pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].ar_amt_target != None else int((amt_setting/100) * target_resp[i].channel.capacity)
+            item['ar_in_target'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].ar_in_target if updated and pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].ar_in_target != None else inbound_setting
+            item['ar_out_target'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].ar_out_target if updated and pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].ar_out_target != None else outbound_setting
+            item['ar_max_cost'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].ar_max_cost if updated and pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].ar_max_cost != None else cost_setting
+            item['auto_fees'] = pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].auto_fees if updated and pending_changes.filter(funding_txid=funding_txid,output_index=output_index)[0].auto_fees != None else (False if auto_fees == 0 else True)
+            pending_open.append(item)
+    if pending_channels.pending_closing_channels:
+        target_resp = pending_channels.pending_closing_channels
+        pending_closed = []
+        for i in range(0,len(target_resp)):
+            pending_item = {'remote_node_pub':target_resp[i].channel.remote_node_pub,'channel_point':target_resp[i].channel.channel_point,'capacity':target_resp[i].channel.capacity,'local_balance':target_resp[i].channel.local_balance,'remote_balance':target_resp[i].channel.remote_balance,'local_chan_reserve_sat':target_resp[i].channel.local_chan_reserve_sat,
+            'remote_chan_reserve_sat':target_resp[i].channel.remote_chan_reserve_sat,'initiator':target_resp[i].channel.initiator,'commitment_type':target_resp[i].channel.commitment_type, 'local_commit_fee_sat': target_resp[i].commitments.local_commit_fee_sat,'limbo_balance':target_resp[i].limbo_balance,'closing_txid':target_resp[i].closing_txid}
+            pending_item.update(pending_channel_details(target_resp[i].channel.channel_point))
+            pending_closed.append(pending_item)
+    if pending_channels.pending_force_closing_channels:
+        target_resp = pending_channels.pending_force_closing_channels
+        pending_force_closed = []
+        for i in range(0,len(target_resp)):
+            pending_item = {'remote_node_pub':target_resp[i].channel.remote_node_pub,'channel_point':target_resp[i].channel.channel_point,'capacity':target_resp[i].channel.capacity,'local_balance':target_resp[i].channel.local_balance,'remote_balance':target_resp[i].channel.remote_balance,'initiator':target_resp[i].channel.initiator,
+            'commitment_type':target_resp[i].channel.commitment_type,'closing_txid':target_resp[i].closing_txid,'limbo_balance':target_resp[i].limbo_balance,'maturity_height':target_resp[i].maturity_height,'blocks_til_maturity':target_resp[i].blocks_til_maturity if target_resp[i].blocks_til_maturity > 0 else find_next_block_maturity(target_resp[i]),
+            'maturity_datetime':(datetime.now()+timedelta(minutes=(10*target_resp[i].blocks_til_maturity if target_resp[i].blocks_til_maturity > 0 else 10*find_next_block_maturity(target_resp[i]) )))}
+            pending_item.update(pending_channel_details(target_resp[i].channel.channel_point))
+            pending_force_closed.append(pending_item)
+    if pending_channels.waiting_close_channels:
+        target_resp = pending_channels.waiting_close_channels
+        waiting_for_close = []
+        for i in range(0,len(target_resp)):
+            pending_closing_balance += target_resp[i].limbo_balance
+            pending_item = {'remote_node_pub':target_resp[i].channel.remote_node_pub,'channel_point':target_resp[i].channel.channel_point,'capacity':target_resp[i].channel.capacity,'local_balance':target_resp[i].channel.local_balance,'remote_balance':target_resp[i].channel.remote_balance,'local_chan_reserve_sat':target_resp[i].channel.local_chan_reserve_sat,
+            'remote_chan_reserve_sat':target_resp[i].channel.remote_chan_reserve_sat,'initiator':target_resp[i].channel.initiator,'commitment_type':target_resp[i].channel.commitment_type, 'local_commit_fee_sat': target_resp[i].commitments.local_commit_fee_sat, 'limbo_balance':target_resp[i].limbo_balance,'closing_txid':target_resp[i].closing_txid}
+            pending_item.update(pending_channel_details(target_resp[i].channel.channel_point))
+            waiting_for_close.append(pending_item)
+    limbo_balance -= pending_closing_balance
+    try:
+        db_size = round(path.getsize(path.expanduser(settings.LND_DATABASE_PATH))*0.000000001, 3)
+    except:
+        db_size = 0
+    return Response({
+        'num_peers': node_info.num_peers,
+        'synced_to_graph': node_info.synced_to_graph,
+        'synced_to_chain': node_info.synced_to_chain,
+        'num_active_channels': node_info.num_active_channels,
+        'num_inactive_channels': node_info.num_inactive_channels,
+        'chains': [chain.chain+"-"+chain.network for chain in node_info.chains],
+        'block': {'hash': node_info.block_hash, 'height': node_info.block_height},
+        'balance': {
+            'limbo': limbo_balance,
+            'onchain': balances.total_balance,
+            'confirmed': balances.confirmed_balance,
+            'unconfirmed': balances.unconfirmed_balance,
+            'total': balances.total_balance + pending_open_balance + limbo_balance,
+        },
+        'pending_open': pending_open,
+        'pending_closed': pending_closed,
+        'pending_force_closed': pending_force_closed,
+        'waiting_for_close': waiting_for_close,
+        'db_size': db_size
+    })
 
 @api_view(['POST'])
 @is_login_required(permission_classes([IsAuthenticated]), settings.LOGIN_REQUIRED)


### PR DESCRIPTION
This PR adds a new endpoint `api/node_info` to periodically retrieve dynamic data from lnd grpc calls.

Notes:
- periodic calls are 21 seconds cycle
- these calls are only made if browser tab is active (it stops requesting new data from api if tab is not visible)
- failed HTLCs & invoices are also not updated each cycle (I believe it would be an overhead with little gain in usefulness + their info do not help in building derived info such as: cost, routed, fees, etc)
