### PR TITLE
v1.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,13 @@ Alternatively, you may also make your own task for these files with your preferr
 2. `-dir` or `--lnddir` - LND Directory for tls cert and admin macaroon paths (or see commands below to set custom values) - default: `~/.lnd`
 3. `-net` or `--network` - Network LND will run over - default: `mainnet`
 4. `-server` or `--rpcserver` - Server address to use for rpc communications with LND - default: `localhost:10009`
-5. `-sd` or `--supervisord` - Setup supervisord to run jobs/rebalancer background processes - default: `False`
-6. `-sdu` or `--sduser` - Configure supervisord with a non-root user - default: `root`
-7. `-wn` or `--whitenoise` - Add whitenoise middleware (docker requirement for static files) - default: `False`
-8. `-d` or `--docker` - Single option for docker container setup (supervisord + whitenoise) - default: `False`
-9. `-dx` or `--debug` - Setup the django site in debug mode - default: `False`
-10. `-u` or `--adminuser` Setup a custom admin username - default: `lndg-admin`
+5. `-maxmsg` or `--maxmessage` - Maximum message size for grpc communications (MB) - default: `30`
+6. `-sd` or `--supervisord` - Setup supervisord to run jobs/rebalancer background processes - default: `False`
+7. `-sdu` or `--sduser` - Configure supervisord with a non-root user - default: `root`
+8. `-wn` or `--whitenoise` - Add whitenoise middleware (docker requirement for static files) - default: `False`
+9. `-d` or `--docker` - Single option for docker container setup (supervisord + whitenoise) - default: `False`
+10. `-dx` or `--debug` - Setup the django site in debug mode - default: `False`
+11. `-u` or `--adminuser` Setup a custom admin username - default: `lndg-admin`
 10. `-pw` or `--adminpw` Setup a custom admin password - default: `Randomized`
 10. `-csrf` or `--csrftrusted` Set trusted CSRF origins - default: `None`
 10. `-tls` or `--tlscert` Set a custom path to the tls cert - default: `--lnddir used`
@@ -164,15 +165,16 @@ You can customize some settings of AF by updating the following settings:
 `AF-Increment` - The increment size of our potential fee changes, all fee suggestions will be a multiple of this value  
 `AF-MaxRate` - The maximum fee rate in which we can adjust to  
 `AF-MinRate` - The minimum fee rate in which we can adjust to  
-`AF-Multiplier` - Multiplier used against the flow pattern algorithm, the larger the multiplier, the larger the potential moves  
+`AF-Multiplier` - Multiplier to increase incremental movements, the larger the multiplier, the larger the incremental moves  
 `AF-UpdateHours` - Change the number of hours that must pass since the last fee rate change before AF may adjust the fee rate again  
+`AF-LowLiqLimit` - The liquidity (%) a channel must drop below before running the `Low Liquidity` fee algorithm  
+`AF-ExcessLimit` - The liquidity (%) a channel must go above before running the `Excess Liquidity` fee algorithm  
 
 AF Notes:
-1. AF changes only trigger after 24 hours (default) of no fee updates via LNDg
-2. Single step maximum increase set to 15% or 25 ppm (which ever is increase smaller)
-3. Single step maximum decrease set to 25% or 50 ppm (which ever is decrease smaller)
-4. Channels with less than 25% outbound liquidty will not have their fees decreased
-5. Channels with less than 25% inbound liquidty will not have their fees increased
+1. AF changes only trigger after `AF-UpdateHours` hours of no fee updates via LNDg
+2. Channels with less than `AF-LowLiqLimit` outbound liquidty will increase based on failed HTLC counts and incoming flow
+3. Channels with more than `AF-ExcessLimit` outbound liquidty will decrease based on no flows or assisted revenues
+4. Channels between the previous two groups will increase or decrease based on flow
 
 ## Auto-Rebalancer - [Quick Start Guide](https://github.com/cryptosharks131/lndg/blob/master/quickstart.md)
 ### Here are some additional notes to help you better understand the Auto-Rebalancer (AR).

--- a/gui/af.py
+++ b/gui/af.py
@@ -46,12 +46,12 @@ def main(channels):
             lowliq_limit = int(LocalSettings.objects.filter(key='AF-LowLiqLimit').get().value)
         else:
             LocalSettings(key='AF-LowLiqLimit', value='5').save()
-            lowliq_limit = 15
+            lowliq_limit = 5
         if LocalSettings.objects.filter(key='AF-ExcessLimit').exists():
             excess_limit = int(LocalSettings.objects.filter(key='AF-ExcessLimit').get().value)
         else:
             LocalSettings(key='AF-ExcessLimit', value='95').save()
-            excess_limit = 90
+            excess_limit = 95
         if lowliq_limit >= excess_limit:
             print('Invalid thresholds detected, using defaults...')
             lowliq_limit = 5

--- a/gui/lnd_deps/lnd_connect.py
+++ b/gui/lnd_deps/lnd_connect.py
@@ -16,10 +16,10 @@ def creds():
     return creds
 
 def lnd_connect():
-    return grpc.secure_channel(settings.LND_RPC_SERVER, creds(), options=[('grpc.max_send_message_length', 29999999), ('grpc.max_receive_message_length', 29999999),])
+    return grpc.secure_channel(settings.LND_RPC_SERVER, creds(), options=[('grpc.max_send_message_length', int(settings.LND_MAX_MESSAGE)*1000000), ('grpc.max_receive_message_length', int(settings.LND_MAX_MESSAGE)*1000000),])
 
 def async_lnd_connect():
-    return grpc.aio.secure_channel(settings.LND_RPC_SERVER, creds(), options=[('grpc.max_send_message_length', 29999999), ('grpc.max_receive_message_length', 29999999),])
+    return grpc.aio.secure_channel(settings.LND_RPC_SERVER, creds(), options=[('grpc.max_send_message_length', int(settings.LND_MAX_MESSAGE)*1000000), ('grpc.max_receive_message_length', int(settings.LND_MAX_MESSAGE)*1000000),])
 
 def main():
     pass

--- a/gui/templates/base.html
+++ b/gui/templates/base.html
@@ -90,7 +90,7 @@
         <center><button id="toggleTheme" onclick="toggleTheme()">Toggle dark mode</button></center>
       </div>
       <div class="w3-container w3-padding-small">
-        <center>LNDg v1.7.0</center>
+        <center>LNDg v1.7.1</center>
       </div>
     </div>
   </footer>

--- a/initialize.py
+++ b/initialize.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.conf import settings
 BASE_DIR = Path(__file__).resolve().parent
 
-def write_settings(node_ip, lnd_tls_path, lnd_macaroon_path, lnd_database_path, lnd_network, lnd_rpc_server, whitenoise, debug, csrftrusted, nologinrequired):
+def write_settings(node_ip, lnd_tls_path, lnd_macaroon_path, lnd_database_path, lnd_network, lnd_rpc_server, lnd_max_message, whitenoise, debug, csrftrusted, nologinrequired):
     #Generate a unique secret to be used for your django site
     secret = secrets.token_urlsafe(64)
     if whitenoise:
@@ -61,6 +61,7 @@ LND_MACAROON_PATH = '%s'
 LND_DATABASE_PATH = '%s'
 LND_NETWORK = '%s'
 LND_RPC_SERVER = '%s'
+LND_MAX_MESSAGE = '%s'
 LOGIN_REQUIRED = %s
 
 # Application definition
@@ -170,7 +171,7 @@ USE_TZ = False
 STATIC_URL = 'static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'gui/static/')
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
-''' % (secret, debug, node_ip, csrf, lnd_tls_path, lnd_macaroon_path, lnd_database_path, lnd_network, lnd_rpc_server, not nologinrequired, wnl, api_login)
+''' % (secret, debug, node_ip, csrf, lnd_tls_path, lnd_macaroon_path, lnd_database_path, lnd_network, lnd_rpc_server, lnd_max_message, not nologinrequired, wnl, api_login)
     try:
         f = open("lndg/settings.py", "x")
         f.close()
@@ -261,6 +262,7 @@ def main():
     parser.add_argument('-dir', '--lnddir',help = 'LND Directory for tls cert and admin macaroon paths', default=None)
     parser.add_argument('-net', '--network', help = 'Network LND will run over', default='mainnet')
     parser.add_argument('-server', '--rpcserver', help = 'Server address to use for rpc communications with LND', default='localhost:10009')
+    parser.add_argument('-maxmsg', '--maxmessage', help = 'Maximum message size for grpc communications (MB)', default='35')
     parser.add_argument('-sd', '--supervisord', help = 'Setup supervisord to run jobs/rebalancer background processes', action='store_true')
     parser.add_argument('-sdu', '--sduser', help = 'Configure supervisord with a non-root user', default='root')
     parser.add_argument('-wn', '--whitenoise', help = 'Add whitenoise middleware (docker requirement for static files)', action='store_true')
@@ -278,6 +280,7 @@ def main():
     lnd_dir_path = args.lnddir if args.lnddir else '~/.lnd'
     lnd_network = args.network
     lnd_rpc_server = args.rpcserver
+    lnd_max_message = args.maxmessage
     setup_supervisord = args.supervisord
     sduser = args.sduser
     whitenoise = args.whitenoise
@@ -293,7 +296,7 @@ def main():
     if docker:
         setup_supervisord = True
         whitenoise = True
-    write_settings(node_ip, lnd_tls_path, lnd_macaroon_path, lnd_database_path, lnd_network, lnd_rpc_server, whitenoise, debug, csrftrusted, nologinrequired)
+    write_settings(node_ip, lnd_tls_path, lnd_macaroon_path, lnd_database_path, lnd_network, lnd_rpc_server, lnd_max_message, whitenoise, debug, csrftrusted, nologinrequired)
     if setup_supervisord:
         print('Supervisord setup requested...')
         write_supervisord_settings(sduser)


### PR DESCRIPTION
-Allow for customization of the max message size for gRPC communications
-Updated new default max message size to 35MB
-Fixed small discrepensary for the first run of the `af.py`