### PR TITLE
[bug] actions: add missing node pubkey

### DIFF
--- a/gui/views.py
+++ b/gui/views.py
@@ -1139,6 +1139,7 @@ def actions(request):
             result = {}
             result['chan_id'] = channel.chan_id
             result['short_chan_id'] = channel.short_chan_id
+            result['remote_pubkey'] = channel.remote_pubkey
             result['alias'] = channel.alias
             result['capacity'] = channel.capacity
             result['local_balance'] = channel.local_balance + channel.pending_outbound


### PR DESCRIPTION
`Rocket Node` via Telegram: 
> On the /actions page.. the link for the peer alias doesn't include the nodeid

This PR fixes a small bug by populating the peer's pubkey on `/actions` page.