### PR TITLE
Disconnect Peers with expiring htlc within 13 blocks

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -176,6 +176,8 @@ def disconnecthtlcpeer(stub, htlc, peerpubkey):
                 peer.save()
             except Exception as e:
                 print(f"{datetime.now().strftime('%c')} : .... Error disconnecting peer {peer.alias} {peer.pubkey=} {str(e)=}")
+            peer.last_reconnected = datetime.now() #Reconnect will be done by lnd on its own (or by the reconnect function). Setting time to ensure next disconnect occurs after 1 block.
+            peer.save()
         #else:
             #print(f"{datetime.now().strftime('%c')} : .... Skip Disconnected peer {peer.alias} {peer.pubkey=} {int((datetime.now() - peer.last_reconnected).total_seconds() / 60)=}")
 

--- a/jobs.py
+++ b/jobs.py
@@ -172,8 +172,6 @@ def disconnecthtlcpeer(stub, htlc, peerpubkey):
                 response = stub.DisconnectPeer(ln.DisconnectPeerRequest(pub_key=peerpubkey))
                 print(f"{datetime.now().strftime('%c')} : .... Disconnected peer with expiring htlc {peer.alias} {peer.pubkey=} {int((datetime.now() - peer.last_reconnected).total_seconds() / 60)=} {htlc.expiration_height=} {htlc.hash_lock.hex()=}")
                 peer.connected = False
-                peer.last_reconnected = datetime.now() #Reconnect will be done by lnd on its own (or by the reconnect function). Setting time to ensure next disconnect occurs after 1 block.
-                peer.save()
             except Exception as e:
                 print(f"{datetime.now().strftime('%c')} : .... Error disconnecting peer {peer.alias} {peer.pubkey=} {str(e)=}")
             peer.last_reconnected = datetime.now() #Reconnect will be done by lnd on its own (or by the reconnect function). Setting time to ensure next disconnect occurs after 1 block.

--- a/rebalancer.py
+++ b/rebalancer.py
@@ -58,9 +58,8 @@ async def run_rebalancer(rebalance, worker):
             chan_ids = json.loads(rebalance.outgoing_chan_ids)
             timeout = rebalance.duration * 60
             invoice_response = stub.AddInvoice(ln.Invoice(value=rebalance.value, expiry=timeout))
-            print(f"{datetime.now().strftime('%c')} : [Rebalancer] : {worker} starting rebalance for: {rebalance.target_alias} {rebalance.last_hop_pubkey=} {rebalance.value=} {rebalance.duration=} {chan_ids=}")
+            print(f"{datetime.now().strftime('%c')} : [Rebalancer] : {worker} starting rebalance for {rebalance.target_alias} {rebalance.last_hop_pubkey} for {rebalance.value} sats and duration {rebalance.duration}, using {len(chan_ids)} outbound channels")
             async for payment_response in routerstub.SendPaymentV2(lnr.SendPaymentRequest(payment_request=str(invoice_response.payment_request), fee_limit_msat=int(rebalance.fee_limit*1000), outgoing_chan_ids=chan_ids, last_hop_pubkey=bytes.fromhex(rebalance.last_hop_pubkey), timeout_seconds=(timeout-5), allow_self_payment=True), timeout=(timeout+60)):
-                #print(f"{datetime.now().strftime('%c')} : [Rebalancer] : DEBUG {worker} got a payment response: {payment_response.status=} {payment_response.failure_reason=} {payment_response.payment_hash=}")
                 if payment_response.status == 1 and rebalance.status == 0:
                     #IN-FLIGHT
                     rebalance.payment_hash = payment_response.payment_hash
@@ -99,7 +98,7 @@ async def run_rebalancer(rebalance, worker):
         finally:
             rebalance.stop = datetime.now()
             await save_record(rebalance)
-            print(f"{datetime.now().strftime('%c')} : [Rebalancer] : {worker} completed payment attempts for: {rebalance.payment_hash=}")
+            print(f"{datetime.now().strftime('%c')} : [Rebalancer] : {worker} completed payment attempts for: {rebalance.payment_hash}")
             original_alias = rebalance.target_alias
             inc=1.21
             dec=2
@@ -112,7 +111,7 @@ async def run_rebalancer(rebalance, worker):
                 if await inbound_cans_len(inbound_cans) > 0 and len(outbound_cans) > 0:
                     next_rebalance = Rebalancer(value=int(rebalance.value*inc), fee_limit=round(rebalance.fee_limit*inc, 3), outgoing_chan_ids=str(outbound_cans).replace('\'', ''), last_hop_pubkey=rebalance.last_hop_pubkey, target_alias=original_alias, duration=1)
                     await save_record(next_rebalance)
-                    print(f"{datetime.now().strftime('%c')} : [Rebalancer] : RapidFire up {next_rebalance.target_alias=} {next_rebalance.value=} {rebalance.value=}")
+                    print(f"{datetime.now().strftime('%c')} : [Rebalancer] : RapidFire increase for {next_rebalance.target_alias} from {next_rebalance.value} to {rebalance.value}")
                 else:
                     next_rebalance = None
             # For failed rebalances, try in rapid fire with reduced balances until give up.
@@ -130,7 +129,7 @@ async def run_rebalancer(rebalance, worker):
                 if await inbound_cans_len(inbound_cans) > 0 and len(outbound_cans) > 0:
                     next_rebalance = Rebalancer(value=int(next_value), fee_limit=round(rebalance.fee_limit/(rebalance.value/next_value), 3), outgoing_chan_ids=str(outbound_cans).replace('\'', ''), last_hop_pubkey=rebalance.last_hop_pubkey, target_alias=original_alias, duration=1)
                     await save_record(next_rebalance)
-                    print(f"{datetime.now().strftime('%c')} : [Rebalancer] : RapidFire Down {next_rebalance.target_alias=} {next_rebalance.value=} {rebalance.value=}")
+                    print(f"{datetime.now().strftime('%c')} : [Rebalancer] : RapidFire decrease for {next_rebalance.target_alias} from {next_rebalance.value} to {rebalance.value}")
                 else:
                     next_rebalance = None
             else:
@@ -147,14 +146,10 @@ def estimate_liquidity( payment ):
             attempt = None
             for attempt in payment.htlcs:
                 total_hops=len(attempt.route.hops)
-                #Failure Codes https://github.com/lightningnetwork/lnd/blob/9f013f5058a7780075bca393acfa97aa0daec6a0/lnrpc/lightning.proto#L4200
-                #print(f"{datetime.now().strftime('%c')} : [Rebalancer] : DEBUG Liquidity Estimation {attempt.attempt_id=} {attempt.status=} {attempt.failure.code=} {attempt.failure.failure_source_index=} {total_hops=} {attempt.route.total_amt=} {payment.value_msat/1000=} {estimated_liquidity=} {payment.payment_hash=}")
                 if attempt.failure.failure_source_index == total_hops:
                     #Failure from last hop indicating liquidity available
                     estimated_liquidity = attempt.route.total_amt if attempt.route.total_amt > estimated_liquidity else estimated_liquidity
-                    chan_id=attempt.route.hops[len(attempt.route.hops)-1].chan_id
-                    #print(f"{datetime.now().strftime('%c')} : [Rebalancer] : DEBUG Liquidity Estimation {attempt.attempt_id=} {attempt.status=} {attempt.failure.code=} {chan_id=} {attempt.route.total_amt=} {payment.value_msat/1000=} {estimated_liquidity=} {payment.payment_hash=}")
-        print(f"{datetime.now().strftime('%c')} : [Rebalancer] : Estimated Liquidity {estimated_liquidity=} {payment.payment_hash=} {payment.status=} {payment.failure_reason=}")
+        print(f"{datetime.now().strftime('%c')} : [Rebalancer] : Estimated Liquidity {estimated_liquidity} for payment {payment.payment_hash} with status {payment.status} and reason {payment.failure_reason}")
     except Exception as e:
         print(f"{datetime.now().strftime('%c')} : [Rebalancer] : Error estimating liquidity: {str(e)}")
         estimated_liquidity = 0
@@ -244,10 +239,8 @@ def auto_schedule() -> List[Rebalancer]:
                     if not (last_rebalance.status == 2 or (last_rebalance.status > 2 and (int((datetime.now() - last_rebalance.stop).total_seconds() / 60) > wait_period)) or (last_rebalance.status == 1 and ((int((datetime.now() - last_rebalance.start).total_seconds() / 60) - last_rebalance.duration) > wait_period))):
                         continue
                 print(f"{datetime.now().strftime('%c')} : [Rebalancer] : Creating Auto Rebalance Request for: {target.chan_id}")
-                print(f"{datetime.now().strftime('%c')} : [Rebalancer] : Request routing through: {outbound_cans}")
-                print(f"{datetime.now().strftime('%c')} : [Rebalancer] : {target_value} / {target.ar_amt_target}")
-                print(f"{datetime.now().strftime('%c')} : [Rebalancer] : {target_fee}")
-                print(f"{datetime.now().strftime('%c')} : [Rebalancer] : {target_time}")
+                print(f"{datetime.now().strftime('%c')} : [Rebalancer] : Value: {target_value} / {target.ar_amt_target} | Fee: {target_fee} | Duration: {target_time}")
+                print(f"{datetime.now().strftime('%c')} : [Rebalancer] : Request routing outbound via: {outbound_cans}")
                 new_rebalance = Rebalancer(value=target_value, fee_limit=target_fee, outgoing_chan_ids=str(outbound_cans).replace('\'', ''), last_hop_pubkey=target.remote_pubkey, target_alias=target.alias, duration=target_time)
                 new_rebalance.save()
                 to_schedule.append(new_rebalance)
@@ -283,10 +276,9 @@ def auto_enable():
                 iapD = 0 if routed_in_apday == 0 else int(forwards.filter(chan_id_in__in=chan_list).aggregate(Sum('amt_in_msat'))['amt_in_msat__sum']/10000000)/100
                 oapD = 0 if routed_out_apday == 0 else int(forwards.filter(chan_id_out__in=chan_list).aggregate(Sum('amt_out_msat'))['amt_out_msat__sum']/10000000)/100
                 for peer_channel in lookup_channels.filter(chan_id__in=chan_list):
-                    #print('Processing: ', peer_channel.alias, ' : ', peer_channel.chan_id, ' : ', oapD, " : ", iapD, ' : ', outbound_percent, ' : ', inbound_percent)
                     if peer_channel.ar_out_target == 100 and peer_channel.auto_rebalance == True:
                         #Special Case for LOOP, Wos, etc. Always Auto Rebalance if enabled to keep outbound full.
-                        print(f"{datetime.now().strftime('%c')} : [Rebalancer] : Skipping AR enabled and 100% oTarget channel... {peer_channel.alias=} {peer_channel.chan_id=}")
+                        print(f"{datetime.now().strftime('%c')} : [Rebalancer] : Skipping AR enabled and 100% oTarget channel: {peer_channel.alias} {peer_channel.chan_id}")
                         pass
                     elif oapD > (iapD*1.10) and outbound_percent > 75:
                         #print('Case 1: Pass')
@@ -296,13 +288,13 @@ def auto_enable():
                         peer_channel.auto_rebalance = True
                         peer_channel.save()
                         Autopilot(chan_id=peer_channel.chan_id, peer_alias=peer_channel.alias, setting='Enabled', old_value=0, new_value=1).save()
-                        print(f"{datetime.now().strftime('%c')} : [Rebalancer] : Auto Pilot Enabled: {peer_channel.alias=} {peer_channel.chan_id=} {oapD=} {iapD=}")
+                        print(f"{datetime.now().strftime('%c')} : [Rebalancer] : Auto Pilot Enabled for {peer_channel.alias} {peer_channel.chan_id}: {oapD} {iapD}")
                     elif oapD < (iapD*1.10) and outbound_percent > 75 and peer_channel.auto_rebalance == True:
                         #print('Case 3: Disable AR - o7D < i7D AND Outbound Liq > 75%')
                         peer_channel.auto_rebalance = False
                         peer_channel.save()
                         Autopilot(chan_id=peer_channel.chan_id, peer_alias=peer_channel.alias, setting='Enabled', old_value=1, new_value=0).save()
-                        print(f"{datetime.now().strftime('%c')} : [Rebalancer] : Auto Pilot Disabled (3): {peer_channel.alias=} {peer_channel.chan_id=} {oapD=} {iapD=}" )
+                        print(f"{datetime.now().strftime('%c')} : [Rebalancer] : Auto Pilot Disabled for {peer_channel.alias} {peer_channel.chan_id}: {oapD} {iapD}" )
                     elif oapD < (iapD*1.10) and inbound_percent > 75:
                         #print('Case 4: Pass')
                         pass


### PR DESCRIPTION
A configurable setting is added to allow disconnecting peers who have expiring HTLC within 13 (default) blocks. Can be set via settings. Setting to 0 will disable the feature.