### PR TITLE
Bring liquidity% fields closer to liquidty bar

### DIFF
--- a/gui/templates/base.html
+++ b/gui/templates/base.html
@@ -10,12 +10,14 @@
     const base_ch_template = {
       "remote_pubkey": ch => ({innerHTML: `<a href="/channel?=${ch.chan_id}" target="_blank">${ch.short_chan_id}</a>`, title: `${ch.funding_txid}:${ch.output_index}`}),
       "chan_id": ch => ({innerHTML: `<a href="{{graph_links}}/{{network}}node/${ch.remote_pubkey}" target="_blank">${ch.alias == '' ? ch.remote_pubkey.slice(12) : ch.alias}</a>${ch.notes.length > 0 ? ` <sup href class="w3-round w3-border-small w3-border-grey" title="${ch.notes}">i</sup>` : ''}`, title: ch.remote_pubkey}),
-      "local_balance": ch => ({innerHTML: `${ch.local_balance.intcomma()} <small class="w3-round w3-border-small w3-border-grey">${ch.percent_outbound}%</small>`}),
+      "local_balance": ch => ({innerHTML: ch.local_balance.intcomma()}),
+      "local_balance_percent": ch => ({innerHTML: `<small class="w3-round w3-border-small w3-border-grey">${ch.percent_outbound}%</small>`, style: {textAlign: 'right'}}),
       "capacity": ch => ({innerHTML: `<label>${ch.capacity.intcomma()}</label>
       <div class="progress w3-round w3-grey">
         <span class="value w3-round w3-blue" style="width:${ch.percent_outbound}%"></span>
-      </div>`}),
-      "remote_balance": ch => ({innerHTML: `${ch.remote_balance.intcomma()} <small class="w3-round w3-border-small w3-border-grey">${ch.percent_inbound}%</small>`})
+      </div>`, style:{paddingLeft:0, paddingRight:0}}),
+      "remote_balance_percent": ch => ({innerHTML: `<small class="w3-round w3-border-small w3-border-grey">${ch.percent_inbound}%</small>`, style: {textAlign: 'left'}}),
+      "remote_balance": ch => ({innerHTML: ch.remote_balance.intcomma()})
     }
     const routed_template = {
       "forward_date": f => ({innerHTML: formatDate(f.forward_date), title: adjustTZ(f.forward_date) }),

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -156,9 +156,9 @@
         <tr>
           <th onclick="sortTable(event.target, 0, 'String', 0, 'a')">Channel ID</th>
           <th onclick="sortTable(event.target, 1, 'String', 0, 'a')">Peer Alias</th>
-          <th onclick="sortTable(event.target, 2, 'int')">Outbound Liquidity</th>
+          <th colspan="2" onclick="sortTable(event.target, 2, 'int')">Outbound Liquidity</th>
           <th onclick="sortTable(event.target, 3, 'int', 0, 'label')">Capacity</th>
-          <th onclick="sortTable(event.target, 4, 'int')">Inbound Liquidity</th>
+          <th colspan="2" onclick="sortTable(event.target, 4, 'int')">Inbound Liquidity</th>
           <th onclick="sortTable(event.target, 5, 'int')">Unsettled</th>
           <th width=3% onclick="sortTable(event.target, 6, 'int')">oRate</th>
           <th width=3% onclick="sortTable(event.target, 7, 'int')">oBase</th>

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -157,17 +157,17 @@
           <th onclick="sortTable(event.target, 0, 'String', 0, 'a')">Channel ID</th>
           <th onclick="sortTable(event.target, 1, 'String', 0, 'a')">Peer Alias</th>
           <th colspan="2" onclick="sortTable(event.target, 2, 'int')">Outbound Liquidity</th>
-          <th onclick="sortTable(event.target, 3, 'int', 0, 'label')">Capacity</th>
-          <th colspan="2" onclick="sortTable(event.target, 4, 'int')">Inbound Liquidity</th>
-          <th onclick="sortTable(event.target, 5, 'int')">Unsettled</th>
-          <th width=3% onclick="sortTable(event.target, 6, 'int')">oRate</th>
-          <th width=3% onclick="sortTable(event.target, 7, 'int')">oBase</th>
-          <th onclick="sortTable(event.target, 8, 'm')">o1D</th>
-          <th onclick="sortTable(event.target, 9, 'm')">i1D</th>
-          <th onclick="sortTable(event.target, 10, 'm')">o7D</th>
-          <th onclick="sortTable(event.target, 11, 'm')">i7D</th>
-          <th width=3% onclick="sortTable(event.target, 12, 'int')">iRate</th>
-          <th width=3% onclick="sortTable(event.target, 13, 'int')">iBase</th>
+          <th onclick="sortTable(event.target, 4, 'int', 0, 'label')">Capacity</th>
+          <th colspan="2" onclick="sortTable(event.target, 6, 'int')">Inbound Liquidity</th>
+          <th onclick="sortTable(event.target, 7, 'int')">Unsettled</th>
+          <th width=3% onclick="sortTable(event.target, 8, 'int')">oRate</th>
+          <th width=3% onclick="sortTable(event.target, 9, 'int')">oBase</th>
+          <th onclick="sortTable(event.target, 10, 'm')">o1D</th>
+          <th onclick="sortTable(event.target, 11, 'm')">i1D</th>
+          <th onclick="sortTable(event.target, 12, 'm')">o7D</th>
+          <th onclick="sortTable(event.target, 13, 'm')">i7D</th>
+          <th width=3% onclick="sortTable(event.target, 14, 'int')">iRate</th>
+          <th width=3% onclick="sortTable(event.target, 15, 'int')">iBase</th>
           <th title="When AR is ENABLED for the channel, keep pulling IN to the channel until its inbound liquidity falls below the iTarget%." width=4%>iTarget%</th>
           <th title="When AR is ENABLED it will refill the channel with outbound liquidity." width=4%>AR</th>
         </tr>

--- a/gui/templates/rebalancing.html
+++ b/gui/templates/rebalancing.html
@@ -12,17 +12,17 @@
           <th onclick="sortTable(this, 2, 'String')">Channel ID</th>
           <th onclick="sortTable(this, 3, 'String', 0, 'a')">Peer Alias</th>
           <th colspan="2" onclick="sortTable(event.target, 4, 'int')">Outbound Liquidity</th>
-          <th onclick="sortTable(event.target, 3, 'int', 5, 'label')">Capacity</th>
-          <th colspan="2" onclick="sortTable(event.target, 6, 'int')">Inbound Liquidity</th>
+          <th onclick="sortTable(event.target, 6, 'int', 0, 'label')">Capacity</th>
+          <th colspan="2" onclick="sortTable(event.target, 8, 'int')">Inbound Liquidity</th>
           <th>Rebalance</th>
-          <th onclick="sortTable(this, 8, '%')" title="This ratio must be below the channel's Max Cost %.">Fee Ratio</th>
+          <th onclick="sortTable(this, 10, '%')" title="This ratio must be below the channel's Max Cost %.">Fee Ratio</th>
           <th title="When AR is ENABLED for the channel, the size of the rebalance attempts that should be tried during attempts to refill the channel.">Target Amt</th>
           <th title="When AR is ENABLED, the maximum percentage amount of the local fee rate that can be used for the max rebalancing cost.">Max Cost</th>
           <th title="When AR is NOT ENABLED for the channel, keep pushing OUT the channel until its outbound liquidity falls below the oTarget%.">Out Target</th>
           <th title="When AR is ENABLED for the channel, keep pulling IN to the channel until its inbound liquidity falls below the iTarget%.">In Target</th>
           <th><a href="/rebalancing?is_open=true&private=false&is_active=true&auto_rebalance=true">AR</a></th>
           <th title="The rate of successful rebalances on this channel.">7-Day Rate</th>
-          <th onclick="sortTable(this, 15, 'String')">Active</th>
+          <th onclick="sortTable(this, 17, 'String')">Active</th>
         </tr>
       </thead>
       <tbody id="rebalancingTable">

--- a/gui/templates/rebalancing.html
+++ b/gui/templates/rebalancing.html
@@ -11,9 +11,9 @@
           <th title="Public Key">PK</th>
           <th onclick="sortTable(this, 2, 'String')">Channel ID</th>
           <th onclick="sortTable(this, 3, 'String', 0, 'a')">Peer Alias</th>
-          <th onclick="sortTable(this, 4, 'int')">Outbound Liquidity</th>
-          <th onclick="sortTable(this, 5, 'int', 0, 'label')">Capacity</th>
-          <th onclick="sortTable(this, 6, 'int')">Inbound Liquidity</th>
+          <th colspan="2" onclick="sortTable(event.target, 4, 'int')">Outbound Liquidity</th>
+          <th onclick="sortTable(event.target, 3, 'int', 5, 'label')">Capacity</th>
+          <th colspan="2" onclick="sortTable(event.target, 6, 'int')">Inbound Liquidity</th>
           <th>Rebalance</th>
           <th onclick="sortTable(this, 8, '%')" title="This ratio must be below the channel's Max Cost %.">Fee Ratio</th>
           <th title="When AR is ENABLED for the channel, the size of the rebalance attempts that should be tried during attempts to refill the channel.">Target Amt</th>


### PR DESCRIPTION
Basically transforms this layout:
![image](https://github.com/cryptosharks131/lndg/assets/43297242/84346243-4782-4f0c-b09a-88d7ed3f774a)

into:
![image](https://github.com/cryptosharks131/lndg/assets/43297242/efe29765-900e-4ffa-b655-115732a94afa)

(not sure if this is a better layout, feel free to reject this PR if it doesnt fit)

