### PR TITLE
Summarize Forwards On Home Load

### DIFF
--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -888,18 +888,18 @@
       
       if(forwards_sum[chan_id] === undefined){ forwards_sum[chan_id]={o1d:0, o1dc:0, o7d:0, o7dc:0, i1d:0, i1dc:0, i7d:0, i7dc:0} }
       
-      forwards_sum[chan_id].o1d = f.sum_outgoing_1day/1000
-      forwards_sum[chan_id].o1dc = f.count_outgoing_1day
-      forwards_sum[chan_id].i1d = f.sum_incoming_1day/1000
-      forwards_sum[chan_id].i1dc = f.count_incoming_1day
+      forwards_sum[chan_id].o1d += f.sum_outgoing_1day/1000
+      forwards_sum[chan_id].o1dc += f.count_outgoing_1day
+      forwards_sum[chan_id].i1d += f.sum_incoming_1day/1000
+      forwards_sum[chan_id].i1dc += f.count_incoming_1day
       forwards_summary.o1d += f.sum_outgoing_1day/1000
       forwards_summary.o1dc += f.count_outgoing_1day
       forwards_summary.earned1d += f.sum_fees_1day
 
-      forwards_sum[chan_id].o7d = f.sum_outgoing_7day/1000
-      forwards_sum[chan_id].o7dc = f.count_outgoing_7day
-      forwards_sum[chan_id].i7d = f.sum_incoming_7day/1000
-      forwards_sum[chan_id].i7dc = f.count_incoming_7day
+      forwards_sum[chan_id].o7d += f.sum_outgoing_7day/1000
+      forwards_sum[chan_id].o7dc += f.count_outgoing_7day
+      forwards_sum[chan_id].i7d += f.sum_incoming_7day/1000
+      forwards_sum[chan_id].i7dc += f.count_incoming_7day
       forwards_summary.o7d += f.sum_outgoing_7day/1000
       forwards_summary.o7dc += f.count_outgoing_7day
       forwards_summary.earned7d += f.sum_fees_7day

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -790,10 +790,8 @@
       tableBody.appendChild(use(routed_template).render(f))
     }
   }
-  async function build_routed(forwards7d){
-    let remaining = 20-forwards7d.length, template = use(routed_template), forwards = forwards7d
-    if(remaining > 0)
-      forwards = [...forwards, ...(await GET('forwards', {data: {forward_date__lt: _7days_ago, limit: remaining} })).results]
+  async function build_routed(forwards){
+    let template = use(routed_template)
 
     if(!addTitle('Routed', forwards, `Last <a href="/forwards" target="_blank">Payments Routed</a>`)) return
     const table = byId('routed')
@@ -882,30 +880,29 @@
       table.append(template.render(htlc))
     } 
   }
-  function process_forwards(forwards7d){
+  function process_forwards(forwards){
     let forwards_sum = {}
     let forwards_summary = { o1d: 0, o1dc: 0, o7d: 0, o7dc: 0, earned1d: 0, earned7d: 0 }
-    for(f of forwards7d){
-      chan_out = f.chan_id_out
-      chan_in = f.chan_id_in
-      if(forwards_sum[chan_out] === undefined){ forwards_sum[chan_out]={o1d:0, o1dc:0, o7d:0, o7dc:0, i1d:0, i1dc:0, i7d:0, i7dc:0} }
-      if(forwards_sum[chan_in] === undefined){ forwards_sum[chan_in]={o1d:0, o1dc:0, o7d:0, o7dc:0, i1d:0, i1dc:0, i7d:0, i7dc:0} }
-      if(adjustTZ(f.forward_date) >= _1day_ago){
-        forwards_sum[chan_out].o1d += f.amt_out_msat/1000
-        forwards_sum[chan_out].o1dc += 1
-        forwards_sum[chan_in].i1d += f.amt_in_msat/1000
-        forwards_sum[chan_in].i1dc += 1
-        forwards_summary.o1d += f.amt_out_msat/1000
-        forwards_summary.o1dc += 1
-        forwards_summary.earned1d += f.fee
-      }
-      forwards_sum[chan_out].o7d += f.amt_out_msat/1000
-      forwards_sum[chan_out].o7dc += 1
-      forwards_sum[chan_in].i7d += f.amt_in_msat/1000
-      forwards_sum[chan_in].i7dc += 1
-      forwards_summary.o7d += f.amt_out_msat/1000
-      forwards_summary.o7dc += 1
-      forwards_summary.earned7d += f.fee
+    for(f of forwards){
+      chan_id = f.chan_id
+      
+      if(forwards_sum[chan_id] === undefined){ forwards_sum[chan_id]={o1d:0, o1dc:0, o7d:0, o7dc:0, i1d:0, i1dc:0, i7d:0, i7dc:0} }
+      
+      forwards_sum[chan_id].o1d = f.sum_outgoing_1day/1000
+      forwards_sum[chan_id].o1dc = f.count_outgoing_1day
+      forwards_sum[chan_id].i1d = f.sum_incoming_1day/1000
+      forwards_sum[chan_id].i1dc = f.count_incoming_1day
+      forwards_summary.o1d += f.sum_outgoing_1day/1000
+      forwards_summary.o1dc += f.count_outgoing_1day
+      forwards_summary.earned1d += f.sum_fees_1day
+
+      forwards_sum[chan_id].o7d = f.sum_outgoing_7day/1000
+      forwards_sum[chan_id].o7dc = f.count_outgoing_7day
+      forwards_sum[chan_id].i7d = f.sum_incoming_7day/1000
+      forwards_sum[chan_id].i7dc = f.count_incoming_7day
+      forwards_summary.o7d += f.sum_outgoing_7day/1000
+      forwards_summary.o7dc += f.count_outgoing_7day
+      forwards_summary.earned7d += f.sum_fees_7day
     }
     return [forwards_sum, forwards_summary]
   }
@@ -949,7 +946,8 @@
     buildMainStats(node_info)
     const inv_rev_task = GET('invoices', {data: {state__lt: 2, is_revenue: true, settle_date__gte: _7days_ago}})
     const onchain_task = GET('onchain', {data: {time_stamp__gte: _7days_ago} })
-    const forwards7d_task = GET('forwards', {data: {forward_date__gte: _7days_ago} })
+    const forwardsSummary_task = GET('forwards_summary', {data: {} })
+    const forwardsList_task = GET('forwards', {data: {limit: 20} })
     const payments_task = GET('payments', {data: {creation_date__gte: _7days_ago, status__lt: 3} })
     const closures_task = GET('closures', {data: {close_height__gte: (node_info.block.height - 1008) } })
     const invoices_task = GET('invoices', {data: {state__lt: 2, limit: 10} })
@@ -971,15 +969,15 @@
     byId("updates").innerHTML = updates.intcomma()
     byId("pending_htlcs").innerHTML = pending_htlcs.intcomma()
 
-    let [forwards7d, payments7d] = [(await forwards7d_task).results, (await payments_task).results]
-    let [forwards_sum, forwards_summary] = process_forwards(forwards7d)
+    let [forwardsSummary, payments7d] = [(await forwardsSummary_task).results, (await payments_task).results]
+    let [forwards_sum, forwards_summary] = process_forwards(forwardsSummary)
     let [activeSum, privateSum, inactiveSum] = [build_active(active, forwards_sum), build_private(private), build_inactive(inactive)]
     update_summary(node_info, payments7d, onchain_task, closures_task, activeSum, inactiveSum, privateSum, forwards_summary, inv_rev_task)
     build('Pending Open', pending_open_template, node_info.pending_open||[])
     build('Pending Closed', pending_closed_template, node_info.pending_closed||[])
     build('Waiting For Close', pending_closed_template, node_info.waiting_for_close||[])
     build('Pending Force Closed', pending_fclosed_template, node_info.pending_force_closed||[])
-    build_routed(forwards7d)
+    build_routed((await forwardsList_task).results)
     build_payments(payments7d)
     build_invoices((await invoices_task).results)
     build_failedHTLC((await failedHTLCs_task).results)

--- a/gui/urls.py
+++ b/gui/urls.py
@@ -85,6 +85,7 @@ urlpatterns = [
     path('api/chanpolicy/', views.chan_policy, name='chan-policy'),
     path('api/broadcast_tx/', views.broadcast_tx, name='broadcast-tx'),
     path('api/node_info/', views.node_info, name='node-info'),
+    path('api/forwards_summary/', views.forwards_summary, name='forwards-summary'),
     path('api/sign_message/', views.sign_message, name='sign-message'),
     path('lndg-admin/', admin.site.urls),
 ]

--- a/gui/views.py
+++ b/gui/views.py
@@ -1,7 +1,7 @@
 from django.contrib import messages
 from django.shortcuts import get_object_or_404, render, redirect
 from django.db.models import Sum, IntegerField, Count, Max, F, Q, Case, When, Value, FloatField
-from django.db.models.functions import Round, TruncDay
+from django.db.models.functions import Round, TruncDay, Coalesce
 from django.contrib.auth.decorators import login_required
 from django_filters import FilterSet, CharFilter, DateTimeFilter, NumberFilter
 from datetime import datetime, timedelta
@@ -2186,6 +2186,50 @@ class RebalancerViewSet(viewsets.ReadOnlyModelViewSet):
             return Response(serializer.data)
         return Response(serializer.errors)
 
+@api_view(['GET'])
+@is_login_required(permission_classes([IsAuthenticated]), settings.LOGIN_REQUIRED)
+def forwards_summary(request):
+    filter_1day = datetime.now() - timedelta(days=1)
+    filter_7day = datetime.now() - timedelta(days=7)
+    summary_out = Forwards.objects.values(chan_id=F('chan_id_out')).annotate(
+        count_outgoing_1day=Count('id', filter=Q(forward_date__gte=filter_1day)),
+        sum_outgoing_1day=Coalesce(Sum('amt_out_msat', filter=Q(forward_date__gte=filter_1day)), 0),
+        count_outgoing_7day=Count('id', filter=Q(forward_date__gte=filter_7day)),
+        sum_outgoing_7day=Coalesce(Sum('amt_out_msat', filter=Q(forward_date__gte=filter_7day)), 0),
+        sum_fees_1day=Coalesce(Sum('fee', filter=Q(forward_date__gte=filter_1day)), 0.0),
+        sum_fees_7day=Coalesce(Sum('fee', filter=Q(forward_date__gte=filter_7day)), 0.0),
+        count_incoming_1day=Value(0),
+        sum_incoming_1day=Value(0),
+        count_incoming_7day=Value(0),
+        sum_incoming_7day=Value(0)
+    ).filter(
+        Q(count_outgoing_1day__gt=0) |
+        Q(sum_outgoing_1day__gt=0) |
+        Q(count_outgoing_7day__gt=0) |
+        Q(sum_outgoing_7day__gt=0) |
+        Q(sum_fees_1day__gt=0) |
+        Q(sum_fees_7day__gt=0)
+    )
+
+    summary_in = Forwards.objects.values(chan_id=F('chan_id_in')).annotate(
+        count_outgoing_1day=Value(0),
+        sum_outgoing_1day=Value(0),
+        count_outgoing_7day=Value(0),
+        sum_outgoing_7day=Value(0),
+        sum_fees_1day=Value(0),
+        sum_fees_7day=Value(0),
+        count_incoming_1day=Count('id', filter=Q(forward_date__gte=filter_1day)),
+        sum_incoming_1day=Coalesce(Sum('amt_in_msat', filter=Q(forward_date__gte=filter_1day)), 0),
+        count_incoming_7day=Count('id', filter=Q(forward_date__gte=filter_7day)),
+        sum_incoming_7day=Coalesce(Sum('amt_in_msat', filter=Q(forward_date__gte=filter_7day)), 0)
+    ).filter(
+        Q(count_incoming_1day__gt=0) |
+        Q(sum_incoming_1day__gt=0) |
+        Q(count_incoming_7day__gt=0) |
+        Q(sum_incoming_7day__gt=0)
+    )
+
+    return Response({'results': summary_out.union(summary_in)})
 
 @api_view(['GET'])
 @is_login_required(permission_classes([IsAuthenticated]), settings.LOGIN_REQUIRED)


### PR DESCRIPTION
-Summarize forwards when loading the home page in order to reduce the data that must be sent from server to client
-Addresses slow loading that occurs when many forwards have been processed in the last 7 days