### PR TITLE
Unify logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3-alpine
 ENV PYTHONUNBUFFERED 1
 RUN git clone https://github.com/cryptosharks131/lndg --depth=1 /app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3
 ENV PYTHONUNBUFFERED 1
-RUN git clone https://github.com/cryptosharks131/lndg.git /app
+RUN git clone https://github.com/cryptosharks131/lndg --depth=1 /app
 WORKDIR /app
+RUN git checkout "master"
 RUN pip install -r requirements.txt
 RUN pip install whitenoise
 ENTRYPOINT [ "sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-alpine
 ENV PYTHONUNBUFFERED 1
-RUN git clone https://github.com/cryptosharks131/lndg --depth=1 /app
+RUN apk add git && git clone https://github.com/cryptosharks131/lndg /app
 WORKDIR /app
 RUN git checkout "master"
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3
 ENV PYTHONUNBUFFERED 1
-RUN git clone https://github.com/cryptosharks131/lndg.git /lndg
-WORKDIR /lndg
+RUN git clone https://github.com/cryptosharks131/lndg.git /app
+WORKDIR /app
 RUN pip install -r requirements.txt
-RUN pip install supervisor whitenoise
+RUN pip install whitenoise
+ENTRYPOINT [ "sh" ]

--- a/controller.py
+++ b/controller.py
@@ -15,6 +15,7 @@ def main():
         process.start()
 
     if len(sys.argv) > 1:
+        sys.argv[0] = "manage.py"
         process = multiprocessing.Process(target=manage.main(sys.argv), name="manage.py")
         processes.append(process)
         process.start()

--- a/controller.py
+++ b/controller.py
@@ -1,5 +1,5 @@
-import multiprocessing
-import jobs, rebalancer, htlc_stream, p2p
+import multiprocessing, sys
+import jobs, rebalancer, htlc_stream, p2p, manage
 
 def run_task(task):
     task()
@@ -10,7 +10,12 @@ def main():
 
     processes = []
     for task in tasks:
-        process = multiprocessing.Process(target=run_task, args=(task,))
+        process = multiprocessing.Process(target=run_task, name=task.__module__, args=(task,))
+        processes.append(process)
+        process.start()
+
+    if len(sys.argv) > 1:
+        process = multiprocessing.Process(target=manage.main(sys.argv), name="manage.py")
         processes.append(process)
         process.start()
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,10 +3,9 @@ services:
     build: .
     volumes:
       - /root/.lnd:/root/.lnd:ro
-      - /root/lndg/data:/lndg/data:rw
+      - /root/lndg/data:/app/data:rw
     command:
-      - sh
       - -c
-      - python initialize.py -net 'mainnet' -server 'localhost:10009' -d && supervisord && python manage.py runserver 0.0.0.0:8000
+      - python initialize.py -net 'mainnet' -rpc 'localhost:10009' -wn && python controller.py runserver 0.0.0.0:8000 > /var/log/lndg-controller.log 2>&1
     ports:
       - 8889:8000

--- a/gui/views.py
+++ b/gui/views.py
@@ -231,7 +231,7 @@ def logs(request):
     if request.method == 'GET':
         try:
             count = request.GET.get('tail', 20)
-            logfile = '/var/log/lndg-controller.log' if path.isfile('/var/log/lndg-controller.log') else 'data/lndg-controller.log'
+            logfile = '/var/log/lndg-controller.log'
             file_size = path.getsize(logfile)-2
             if file_size == 0:
                 logs = ['Logs are empty....']

--- a/initialize.py
+++ b/initialize.py
@@ -284,7 +284,7 @@ def initialize_django(adminuser, adminpw):
 def main():
     help_msg = "LNDg Initializer"
     parser = argparse.ArgumentParser(description = help_msg)
-    parser.add_argument('-aip', '--allowed-ip',help = 'Allowed IP to access the LNDg page (IP of the device you want to access LNDg from)', default='*')
+    parser.add_argument('-ip', '--nodeip',help = 'IP that will be used to access the LNDg page', default='*')
     parser.add_argument('-dir', '--lnddir',help = 'LND Directory for tls cert and admin macaroon paths', default=None)
     parser.add_argument('-net', '--network', help = 'Network LND will run over', default='mainnet')
     parser.add_argument('-rpc', '--rpcserver', help = 'Server address to use for rpc communications with LND', default='localhost:10009')

--- a/initialize.py
+++ b/initialize.py
@@ -304,7 +304,7 @@ def main():
     parser.add_argument('-sessionage', '--sessioncookieage', help = 'Number of seconds before the login session expires', default='1209600')
     parser.add_argument('-f', '--force', help = 'Force a new settings file to be created', action='store_true')
     args = parser.parse_args()
-    allowed_remote = args.allowed_ip
+    node_ip = args.nodeip
     lnd_dir_path = args.lnddir if args.lnddir else '~/.lnd'
     lnd_network = args.network
     lnd_rpc_server = args.rpcserver
@@ -326,7 +326,7 @@ def main():
     if docker:
         setup_supervisord = True
         whitenoise = True
-    write_settings(allowed_remote, lnd_tls_path, lnd_macaroon_path, lnd_database_path, lnd_network, lnd_rpc_server, lnd_max_message, whitenoise, debug, csrftrusted, nologinrequired, force_new, cookie_age)
+    write_settings(node_ip, lnd_tls_path, lnd_macaroon_path, lnd_database_path, lnd_network, lnd_rpc_server, lnd_max_message, whitenoise, debug, csrftrusted, nologinrequired, force_new, cookie_age)
     if setup_supervisord:
         print('Supervisord setup requested...')
         write_supervisord_settings(sduser)

--- a/initialize.py
+++ b/initialize.py
@@ -284,10 +284,10 @@ def initialize_django(adminuser, adminpw):
 def main():
     help_msg = "LNDg Initializer"
     parser = argparse.ArgumentParser(description = help_msg)
-    parser.add_argument('-ip', '--nodeip',help = 'IP that will be used to access the LNDg page', default='*')
+    parser.add_argument('-aip', '--allowed-ip',help = 'Allowed IP to access the LNDg page (IP of the device you want to access LNDg from)', default='*')
     parser.add_argument('-dir', '--lnddir',help = 'LND Directory for tls cert and admin macaroon paths', default=None)
     parser.add_argument('-net', '--network', help = 'Network LND will run over', default='mainnet')
-    parser.add_argument('-server', '--rpcserver', help = 'Server address to use for rpc communications with LND', default='localhost:10009')
+    parser.add_argument('-rpc', '--rpcserver', help = 'Server address to use for rpc communications with LND', default='localhost:10009')
     parser.add_argument('-maxmsg', '--maxmessage', help = 'Maximum message size for grpc communications (MB)', default='35')
     parser.add_argument('-sd', '--supervisord', help = 'Setup supervisord to run jobs/rebalancer background processes', action='store_true')
     parser.add_argument('-sdu', '--sduser', help = 'Configure supervisord with a non-root user', default='root')
@@ -304,7 +304,7 @@ def main():
     parser.add_argument('-sessionage', '--sessioncookieage', help = 'Number of seconds before the login session expires', default='1209600')
     parser.add_argument('-f', '--force', help = 'Force a new settings file to be created', action='store_true')
     args = parser.parse_args()
-    node_ip = args.nodeip
+    allowed_remote = args.allowed_ip
     lnd_dir_path = args.lnddir if args.lnddir else '~/.lnd'
     lnd_network = args.network
     lnd_rpc_server = args.rpcserver
@@ -326,7 +326,7 @@ def main():
     if docker:
         setup_supervisord = True
         whitenoise = True
-    write_settings(node_ip, lnd_tls_path, lnd_macaroon_path, lnd_database_path, lnd_network, lnd_rpc_server, lnd_max_message, whitenoise, debug, csrftrusted, nologinrequired, force_new, cookie_age)
+    write_settings(allowed_remote, lnd_tls_path, lnd_macaroon_path, lnd_database_path, lnd_network, lnd_rpc_server, lnd_max_message, whitenoise, debug, csrftrusted, nologinrequired, force_new, cookie_age)
     if setup_supervisord:
         print('Supervisord setup requested...')
         write_supervisord_settings(sduser)

--- a/initialize.py
+++ b/initialize.py
@@ -214,7 +214,7 @@ process_name = lndg-controller
 directory = %s
 autorestart = true
 redirect_stderr = true
-stdout_logfile = %s/data/lndg-controller.log
+stdout_logfile = /var/log/lndg-controller.log
 stdout_logfile_maxbytes = 150MB
 stdout_logfile_backups = 15
 ''' % (sduser, supervisord_secret, supervisord_secret, BASE_DIR, BASE_DIR)

--- a/manage.py
+++ b/manage.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 
-def main():
+def main(args):
     """Run administrative tasks."""
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'lndg.settings')
     try:
@@ -15,8 +15,8 @@ def main():
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
         ) from exc
-    execute_from_command_line(sys.argv)
+    execute_from_command_line(args)
 
 
 if __name__ == '__main__':
-    main()
+    main(sys.argv)


### PR DESCRIPTION
This allows to:
- remove the need to use **supervisord** on _docker containers_
- allows graceful exiting when executing `docker stop` or `^C`
- unifies _manage.py_ and _controller.py_ and therefore unifies logs
- potentially simplifies manual installs (?)

It's possible to run the entire application by using: `python controller.py runserver <addr:port>`

Note: using python:3-alpine reduces the container size from 1.3GB to 352MB in my tests