### PR TITLE
show attempted PPM when HTLC failure reason is Fee Insufficient

### DIFF
--- a/gui/templates/base.html
+++ b/gui/templates/base.html
@@ -69,7 +69,7 @@
       "chan_out_alias": htlc => ({innerHTML: `<a href="/failed_htlcs?=${htlc.chan_id_out}_O" target="_blank">${htlc.chan_out_alias || htlc.chan_id_out}</a>`}),
       "chan_id_out": htlc => ({innerHTML: `<a href="/channel?=${htlc.chan_id_out}" target="_blank">${(BigInt(htlc.chan_id_out)>>40n)+'x'+(BigInt(htlc.chan_id_out)>>16n & BigInt('0xFFFFFF'))+'x'+(BigInt(htlc.chan_id_out) & BigInt('0xFFFF'))}</a>`}),
       "missed_fee": htlc => ({innerHTML: parseFloat(htlc.missed_fee.toFixed(3)).toLocaleString()}),
-      "wire_failure": htlc => ({innerHTML: htlc.wire_failure > wire_failures.length ? htlc.wire_failure : wire_failures[htlc.wire_failure]}),
+      "wire_failure": htlc => ({innerHTML: htlc.wire_failure > wire_failures.length ? htlc.wire_failure : `${wire_failures[htlc.wire_failure]}${htlc.wire_failure===12?` (${Math.ceil(htlc.missed_fee/htlc.amount*1000000)})`:''}`}),
       "failure_detail": htlc => ({innerHTML: htlc.failure_detail > failure_details.length ? htlc.failure_detail : failure_details[htlc.failure_detail]}),
     }
     const peer_events_template = {


### PR DESCRIPTION
Adds the attempted PPM calculation as a parenthetical note to `Fee Insufficient` HTLC failure reason.

<img width="1172" alt="fee_insufficient_ppm" src="https://github.com/cryptosharks131/lndg/assets/155849471/28c70f1d-0a7e-46dc-89c8-10669440fcf0">
