### PR TITLE
jobs: update_channels: handle inbound fees on getchaninfo failures

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -372,6 +372,10 @@ def update_channels(stub):
                 db_channel.remote_disabled = False if db_channel.remote_disabled is None else db_channel.remote_disabled
                 db_channel.remote_min_htlc_msat = -1 if db_channel.remote_min_htlc_msat is None else db_channel.remote_min_htlc_msat
                 db_channel.remote_max_htlc_msat = -1 if db_channel.remote_max_htlc_msat is None else db_channel.remote_max_htlc_msat
+                db_channel.local_inbound_base_fee = -1 if db_channel.local_inbound_base_fee is None else db_channel.local_inbound_base_fee
+                db_channel.local_inbound_fee_rate = -1 if db_channel.local_inbound_fee_rate is None else db_channel.local_inbound_fee_rate
+                db_channel.remote_inbound_base_fee = -1 if db_channel.remote_inbound_base_fee is None else db_channel.remote_inbound_base_fee
+                db_channel.remote_inbound_fee_rate = -1 if db_channel.remote_inbound_fee_rate is None else db_channel.remote_inbound_fee_rate
         # Check for pending settings to be applied
         if pending_channel:
             if pending_channel.local_base_fee or pending_channel.local_fee_rate or pending_channel.local_cltv:


### PR DESCRIPTION
The new fields added with the addition of inbound fees in LND (see https://docs.lightning.engineering/lightning-network-tools/lnd/inbound-channel-fees) were not being handled properly in case of an `edge not found` error being return from the `GetChanInfo` call, employed in the `update_channels` job.

This would prevent channels proceeding the problematic channels in question to not be properly added to the lndg database.