### PR TITLE
Change docker compose logs volume

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     volumes:
       - /root/.lnd:/root/.lnd:ro
       - /root/lndg/data:/app/data:rw
-      - /root/lndg/data/lndg-controller.log:/var/log/lndg-controller.log:rw
+      - /root/lndg/data/logs:/var/log:rw
     command:
       - sh
       - -c


### PR DESCRIPTION
I was not able to run this docker compose file since Docker created this folder `/root/lndg/data/lndg-controller.log` instead of a file.
I switched this to just mounting a `logs` directory where the log files could be written to