### PR TITLE
New card: Unprofitable channels 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ lndg-admin.txt
 gui/static/admin
 gui/static/rest_framework
 data/
+logs/

--- a/af.py
+++ b/af.py
@@ -11,58 +11,167 @@ def main(channels):
     channels_df = DataFrame.from_records(channels.values())
     filter_1day = datetime.now() - timedelta(days=1)
     filter_7day = datetime.now() - timedelta(days=7)
-    if channels_df.shape[0] > 0:
-        if LocalSettings.objects.filter(key='AF-MaxRate').exists():
-            max_rate = int(LocalSettings.objects.filter(key='AF-MaxRate')[0].value)
-        else:
-            LocalSettings(key='AF-MaxRate', value='2500').save()
-            max_rate = 2500
-        if LocalSettings.objects.filter(key='AF-MinRate').exists():
-            min_rate = int(LocalSettings.objects.filter(key='AF-MinRate')[0].value)
-        else:
-            LocalSettings(key='AF-MinRate', value='0').save()
-            min_rate = 0
-        if LocalSettings.objects.filter(key='AF-Increment').exists():
-            increment = int(LocalSettings.objects.filter(key='AF-Increment')[0].value)
-        else:
-            LocalSettings(key='AF-Increment', value='5').save()
-            increment = 5
-        if LocalSettings.objects.filter(key='AF-Multiplier').exists():
-            multiplier = int(LocalSettings.objects.filter(key='AF-Multiplier')[0].value)
-        else:
-            LocalSettings(key='AF-Multiplier', value='5').save()
-            multiplier = 5
-        if LocalSettings.objects.filter(key='AF-FailedHTLCs').exists():
-            failed_htlc_limit = int(LocalSettings.objects.filter(key='AF-FailedHTLCs')[0].value)
-        else:
-            LocalSettings(key='AF-FailedHTLCs', value='25').save()
-            failed_htlc_limit = 25
-        if LocalSettings.objects.filter(key='AF-UpdateHours').exists():
-            update_hours = int(LocalSettings.objects.filter(key='AF-UpdateHours').get().value)
-        else:
-            LocalSettings(key='AF-UpdateHours', value='24').save()
-            update_hours = 24
-        if LocalSettings.objects.filter(key='AF-LowLiqLimit').exists():
-            lowliq_limit = int(LocalSettings.objects.filter(key='AF-LowLiqLimit').get().value)
-        else:
-            LocalSettings(key='AF-LowLiqLimit', value='15').save()
-            lowliq_limit = 5
-        if LocalSettings.objects.filter(key='AF-ExcessLimit').exists():
-            excess_limit = int(LocalSettings.objects.filter(key='AF-ExcessLimit').get().value)
-        else:
-            LocalSettings(key='AF-ExcessLimit', value='95').save()
-            excess_limit = 95
-        if lowliq_limit >= excess_limit:
-            print('Invalid thresholds detected, using defaults...')
-            lowliq_limit = 5
-            excess_limit = 95
-        forwards = Forwards.objects.filter(forward_date__gte=filter_7day, amt_out_msat__gte=1000000)
-        forwards_1d = forwards.filter(forward_date__gte=filter_1day)
-        if forwards_1d.exists():
-            forwards_df_in_1d_sum = DataFrame.from_records(forwards_1d.values('chan_id_in').annotate(amt_out_msat=Sum('amt_out_msat'), fee=Sum('fee')), 'chan_id_in')
-            if forwards.exists():
-                forwards_df_in_7d_sum = DataFrame.from_records(forwards.values('chan_id_in').annotate(amt_out_msat=Sum('amt_out_msat'), fee=Sum('fee')), 'chan_id_in')
-                forwards_df_out_7d_sum = DataFrame.from_records(forwards.values('chan_id_out').annotate(amt_out_msat=Sum('amt_out_msat'), fee=Sum('fee')), 'chan_id_out')
+    if LocalSettings.objects.filter(key='AF-MaxRate').exists():
+        max_rate = int(LocalSettings.objects.filter(key='AF-MaxRate')[0].value)
+    else:
+        LocalSettings(key='AF-MaxRate', value='2500').save()
+        max_rate = 2500
+    if LocalSettings.objects.filter(key='AF-MinRate').exists():
+        min_rate = int(LocalSettings.objects.filter(key='AF-MinRate')[0].value)
+    else:
+        LocalSettings(key='AF-MinRate', value='0').save()
+        min_rate = 0
+    if LocalSettings.objects.filter(key='AF-Increment').exists():
+        increment = int(LocalSettings.objects.filter(key='AF-Increment')[0].value)
+    else:
+        LocalSettings(key='AF-Increment', value='5').save()
+        increment = 5
+    if LocalSettings.objects.filter(key='AF-Multiplier').exists():
+        multiplier = int(LocalSettings.objects.filter(key='AF-Multiplier')[0].value)
+    else:
+        LocalSettings(key='AF-Multiplier', value='5').save()
+        multiplier = 5
+    if LocalSettings.objects.filter(key='AF-FailedHTLCs').exists():
+        failed_htlc_limit = int(LocalSettings.objects.filter(key='AF-FailedHTLCs')[0].value)
+    else:
+        LocalSettings(key='AF-FailedHTLCs', value='25').save()
+        failed_htlc_limit = 25
+    if LocalSettings.objects.filter(key='AF-UpdateHours').exists():
+        update_hours = int(LocalSettings.objects.filter(key='AF-UpdateHours').get().value)
+    else:
+        LocalSettings(key='AF-UpdateHours', value='24').save()
+        update_hours = 24
+    if LocalSettings.objects.filter(key='AF-LowLiqLimit').exists():
+        lowliq_limit = int(LocalSettings.objects.filter(key='AF-LowLiqLimit').get().value)
+    else:
+        LocalSettings(key='AF-LowLiqLimit', value='15').save()
+        lowliq_limit = 5
+    if LocalSettings.objects.filter(key='AF-ExcessLimit').exists():
+        excess_limit = int(LocalSettings.objects.filter(key='AF-ExcessLimit').get().value)
+    else:
+        LocalSettings(key='AF-ExcessLimit', value='95').save()
+        excess_limit = 95
+    if lowliq_limit >= excess_limit:
+        print('Invalid thresholds detected, using defaults...')
+        lowliq_limit = 5
+        excess_limit = 95
+
+    # Fetch forwarding data
+    forwards = Forwards.objects.filter(forward_date__gte=filter_7day, amt_out_msat__gte=1000000)
+    forwards_1d = forwards.filter(forward_date__gte=filter_1day)
+    
+    forwards_df_in_1d_sum = DataFrame.from_records(
+        forwards_1d.values('chan_id_in').annotate(amt_out_msat=Sum('amt_out_msat'), fee=Sum('fee')), 
+        index='chan_id_in'
+    ) if forwards_1d.exists() else DataFrame()
+    
+    forwards_df_in_7d_sum = DataFrame.from_records(
+        forwards.values('chan_id_in').annotate(amt_out_msat=Sum('amt_out_msat'), fee=Sum('fee')), 
+        index='chan_id_in'
+    ) if forwards.exists() else DataFrame()
+    
+    forwards_df_out_7d_sum = DataFrame.from_records(
+        forwards.values('chan_id_out').annotate(amt_out_msat=Sum('amt_out_msat'), fee=Sum('fee')), 
+        index='chan_id_out'
+    ) if forwards.exists() else DataFrame()
+
+    # Compute per-channel metrics
+    if not forwards_df_in_1d_sum.empty:
+        channels_df['amt_routed_in_1day'] = channels_df['chan_id'].map(
+            forwards_df_in_1d_sum['amt_out_msat'].floordiv(1000)
+        ).fillna(0).astype(int)
+    else:
+        channels_df['amt_routed_in_1day'] = 0
+    if not forwards_df_in_7d_sum.empty:
+        channels_df['amt_routed_in_7day'] = channels_df['chan_id'].map(
+            forwards_df_in_7d_sum['amt_out_msat'].floordiv(1000)
+        ).fillna(0).astype(int)
+    else:
+        channels_df['amt_routed_in_7day'] = 0
+    if not forwards_df_out_7d_sum.empty:
+        channels_df['amt_routed_out_7day'] = channels_df['chan_id'].map(
+            forwards_df_out_7d_sum['amt_out_msat'].floordiv(1000)
+        ).fillna(0).astype(int)
+    else:
+        channels_df['amt_routed_out_7day'] = 0
+
+    channels_df['net_routed_7day'] = (
+        (channels_df['amt_routed_out_7day'] - channels_df['amt_routed_in_7day']) / channels_df['capacity']
+    ).round(1)
+    
+    channels_df['local_balance'] = channels_df['local_balance'] + channels_df['pending_outbound']
+    channels_df['remote_balance'] = channels_df['remote_balance'] + channels_df['pending_inbound']
+    channels_df['out_percent'] = ((channels_df['local_balance'] / channels_df['capacity']) * 100).round(0).astype(int)
+    channels_df['in_percent'] = ((channels_df['remote_balance'] / channels_df['capacity']) * 100).round(0).astype(int)
+    channels_df['eligible'] = (datetime.now() - channels_df['fees_updated']).dt.total_seconds() > (update_hours * 3600)
+
+    # Compute failed HTLCs per channel
+    failed_htlc_df = DataFrame.from_records(
+        FailedHTLCs.objects.filter(timestamp__gte=filter_1day, wire_failure=15, failure_detail=6).values()
+    )
+    if not failed_htlc_df.empty:
+        failed_htlc_df = failed_htlc_df[
+            failed_htlc_df['amount'] > (failed_htlc_df['chan_out_liq'] + failed_htlc_df['chan_out_pending'])
+        ]
+        failed_out_1day_series = failed_htlc_df['chan_id_out'].value_counts()
+    else:
+        failed_out_1day_series = Series(dtype='int64')
+    channels_df['failed_out_1day'] = channels_df['chan_id'].map(failed_out_1day_series).fillna(0).astype(int)
+
+    # Compute revenue metrics
+    if not forwards_df_in_7d_sum.empty:
+        channels_df['revenue_assist_7day'] = channels_df['chan_id'].map(
+            forwards_df_in_7d_sum['fee']
+        ).fillna(0).astype(float)
+    else:
+        channels_df['revenue_assist_7day'] = 0.0
+
+    if not forwards_df_out_7d_sum.empty:
+        channels_df['revenue_7day'] = channels_df['chan_id'].map(
+            forwards_df_out_7d_sum['fee']
+        ).fillna(0).astype(float)
+    else:
+        channels_df['revenue_7day'] = 0.0
+
+    # Aggregate data by remote_pubkey
+    group_df = channels_df.groupby('remote_pubkey').agg({
+        'local_balance': 'sum',
+        'capacity': 'sum',
+        'failed_out_1day': 'sum',
+        'amt_routed_in_1day': 'sum',
+        'amt_routed_in_7day': 'sum',
+        'amt_routed_out_7day': 'sum',
+        'revenue_7day': 'sum',
+        'revenue_assist_7day': 'sum'
+    }).rename(columns={
+        'local_balance': 'total_local_balance',
+        'capacity': 'total_capacity',
+        'failed_out_1day': 'total_failed_out_1day',
+        'amt_routed_in_1day': 'total_amt_routed_in_1day',
+        'amt_routed_in_7day': 'total_amt_routed_in_7day',
+        'amt_routed_out_7day': 'total_amt_routed_out_7day',
+        'revenue_7day': 'total_revenue_7day',
+        'revenue_assist_7day': 'total_revenue_assist_7day'
+    })
+
+    group_df['overall_out_percent'] = (
+        (group_df['total_local_balance'] / group_df['total_capacity']) * 100
+    ).where(group_df['total_capacity'] > 0, 0)
+
+    group_df['group_net_routed_7day'] = (
+        (group_df['total_amt_routed_out_7day'] - group_df['total_amt_routed_in_7day']) / group_df['total_capacity']
+    ).where(group_df['total_capacity'] > 0, 0)
+
+    # Define adjustment calculation function
+    def compute_adjustment(row):
+        if row['overall_out_percent'] <= lowliq_limit:
+            return (5 * multiplier) if (row['total_failed_out_1day'] > failed_htlc_limit and 
+                                    row['total_amt_routed_in_1day'] == 0) else 0
+        elif row['overall_out_percent'] < excess_limit:
+            if row['total_amt_routed_in_7day'] + row['total_amt_routed_out_7day'] == 0:
+                return -3 * multiplier
+            elif row['group_net_routed_7day'] > 1:
+                return (2 * multiplier) * (1 + row['group_net_routed_7day'])
             else:
                 forwards_df_in_7d_sum = DataFrame()
                 forwards_df_out_7d_sum = DataFrame()

--- a/gui/templates/base.html
+++ b/gui/templates/base.html
@@ -114,7 +114,7 @@
         <center><button id="toggleTheme" onclick="toggleTheme()">{% if request.COOKIES.darkmode == 'true' %}Light{%else%}Dark{% endif %} Theme</button></center>
       </div>
       <div class="w3-container w3-padding-small">
-        <center>LNDg v1.9.0</center>
+        <center>LNDg v1.9.1</center>
         <center><a href="{% url 'logout' %}">Logout</a></center>
       </div>
     </div>

--- a/gui/templates/home.html
+++ b/gui/templates/home.html
@@ -140,6 +140,7 @@
   <a class="w3-bar-item w3-hover-blue" href="/income" target="_blank">P&L</a>
   <a class="w3-bar-item w3-hover-blue" href="/closures" target="_blank">Closures</a> 
   <a class="w3-bar-item w3-hover-blue" href="/opens" target="_blank">New Peers</a>
+  <a class="w3-bar-item w3-hover-blue" href="/unprofitable_channels" target="_blank">Unprofitable Channels</a>
   <a class="w3-bar-item w3-hover-blue" href="/peerevents" target="_blank">Peer Events</a>
   <a class="w3-bar-item w3-hover-blue" href="/actions" target="_blank">AR Actions</a> 
   <a class="w3-bar-item w3-hover-blue" href="/fees" target="_blank">Fee Rates</a>

--- a/gui/templates/unprofitable_channels.html
+++ b/gui/templates/unprofitable_channels.html
@@ -23,15 +23,15 @@
     <table id="unprofitableChannelsTable" class="w3-table-all w3-centered w3-hoverable">
       <thead>
         <tr>
-          <th onclick="sortTable(0)">Channel ID ↕️</th>
-          <th onclick="sortTable(1)" width=15%>Alias ↕️</th>
-          <th onclick="sortTable(2, true)" width=10%>Routed Out (sats) ↕️</th>
-          <th onclick="sortTable(3)" width=10%>Last Routing ↕️</th>
-          <th onclick="sortTable(4, true)" width=10%>Rebalanced Out (sats) ↕️</th>
-          <th onclick="sortTable(5)" width=10%>Last Rebalance ↕️</th>
-          <th onclick="sortTable(6, true)" width=8%>Profit ↕️</th>
-          <th onclick="sortTable(7, true)" width=8%>Assisted Revenue ↕️</th>
-          <th onclick="sortTable(8)" width=7%>Initiator ↕️</th>
+          <th onclick="sortTable(event.target, 0, 'String', 1)">Channel ID</th>
+          <th onclick="sortTable(event.target, 1, 'String', 1)" width=15%>Alias</th>
+          <th onclick="sortTable(event.target, 2, 'int', 1)" width=10%>Routed Out (sats)</th>
+          <th onclick="sortTable(event.target, 3, 'String', 1)" width=10%>Last Routing</th>
+          <th onclick="sortTable(event.target, 4, 'int', 1)" width=10%>Rebalanced Out (sats)</th>
+          <th onclick="sortTable(event.target, 5, 'String', 1)" width=10%>Last Rebalance</th>
+          <th onclick="sortTable(event.target, 6, 'int', 1)" width=8%>Profit</th>
+          <th onclick="sortTable(event.target, 7, 'int', 1)" width=8%>Assisted Revenue</th>
+          <th onclick="sortTable(event.target, 8, 'String', 1)" width=7%>Initiator</th>
           <th width=10%>Actions</th>
         </tr>
       </thead>
@@ -53,7 +53,15 @@
             <td>{{ channel.assisted_revenue|add:"0"|intcomma }}</td>
             <td>{% if channel.initiator %}Local{% else %}Remote{% endif %}</td>
             <td>
-              <button onclick="copyToClipboard('{{ channel.chan_id }}')" class="w3-button w3-small w3-blue w3-round">Copy ID</button>
+              <a style="display: inline-block;position:relative;width:25px;height:25px" href="#" data-value="{{ channel.chan_id }}" onclick="copyToClipboard('{{ channel.chan_id }}', this)">
+                <svg style="position:absolute;top:0;left:0;width:25px;height:25px" version="1.1" viewBox="0 0 16 16">
+                  <path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path>
+                  <path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path>
+                </svg>
+                <svg class="checkmark" style="position:absolute;top:0;left:0;width:25px;height:25px;visibility:hidden" version="1.1" viewBox="0 0 16 16">
+                  <path style="fill:#3fb950;stroke:#3fb950;" fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+                </svg>
+              </a>
             </td>
           </tr>
         {% endfor %}
@@ -84,83 +92,114 @@
 
 <!-- JavaScript for sorting and copying -->
 <script>
-  function copyToClipboard(text) {
-    navigator.clipboard.writeText(text).then(function() {
-      // Show temporary success message
-      const button = event.target;
-      const originalText = button.textContent;
-      button.textContent = "Copied!";
-      button.style.backgroundColor = "#4CAF50";
+    function copyToClipboard(text, element) {
+      navigator.clipboard.writeText(text).then(function() {
+        // Show visual feedback
+        if (element) {
+          // If using the SVG icon
+          const originalIcon = element.querySelector('svg:first-child');
+          const checkmark = element.querySelector('.checkmark');
+          
+          // Hide original icon and show checkmark
+          originalIcon.style.visibility = 'hidden';
+          checkmark.style.visibility = 'visible';
+          
+          setTimeout(function() {
+            // Restore original icon and hide checkmark
+            originalIcon.style.visibility = 'visible';
+            checkmark.style.visibility = 'hidden';
+          }, 1500);
+        } else {
+          // If using the button
+          const button = event.target;
+          const originalText = button.textContent;
+          button.textContent = "Copied!";
+          button.style.backgroundColor = "#4CAF50";
+          
+          setTimeout(function() {
+            button.textContent = originalText;
+            button.style.backgroundColor = "";
+          }, 1500);
+        }
+      }, function() {
+        console.error('Failed to copy text to clipboard');
+      });
       
-      setTimeout(function() {
-        button.textContent = originalText;
-        button.style.backgroundColor = "";
-      }, 1500);
-    }, function() {
-      console.error('Failed to copy text to clipboard');
-    });
-  }
+      // Prevent default link behavior
+      if (event && event.preventDefault) {
+        event.preventDefault();
+      }
+      return false;
+    }
 
-  function sortTable(n, isNumeric = false) {
+  // Sorting function from channels.html
+  function sortTable(element, n, type, asc, subElement = null) {
     var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
     table = document.getElementById("unprofitableChannelsTable");
     switching = true;
-    // Set the sorting direction to ascending
-    dir = "asc";
-    
+    // Set the sorting direction to ascending:
+    dir = asc ? "asc" : "desc";
+    /* Make a loop that will continue until
+    no switching has been done: */
     while (switching) {
+      // Start by saying: no switching is done:
       switching = false;
       rows = table.rows;
-      
-      // Skip header row and loop through rows
+      /* Loop through all table rows (except the
+      first, which contains table headers): */
       for (i = 1; i < (rows.length - 1); i++) {
+        // Start by saying there should be no switching:
         shouldSwitch = false;
-        
-        // Get the two elements to compare
+        /* Get the two elements you want to compare,
+        one from current row and one from the next: */
         x = rows[i].getElementsByTagName("TD")[n];
         y = rows[i + 1].getElementsByTagName("TD")[n];
-        
-        // Check if the two rows should switch places
-        if (isNumeric) {
-          // Parse numbers (remove commas and other non-numeric characters)
-          var xNum = parseInt(x.innerHTML.replace(/[^0-9.-]+/g, ""));
-          var yNum = parseInt(y.innerHTML.replace(/[^0-9.-]+/g, ""));
-          
-          if (dir == "asc") {
-            if (xNum > yNum) {
+        if (subElement != null) {
+          x = x.getElementsByTagName(subElement)[0];
+          y = y.getElementsByTagName(subElement)[0];
+        }
+        /* Check if the two rows should switch place,
+        based on the direction, asc or desc: */
+        if (dir == "asc") {
+          if (type == "int") {
+            if (parseInt(x.innerHTML.replace(/,/g, '')) > parseInt(y.innerHTML.replace(/,/g, ''))) {
+              // If so, mark as a switch and break the loop:
               shouldSwitch = true;
               break;
             }
-          } else if (dir == "desc") {
-            if (xNum < yNum) {
+          } else {
+            if (x.innerHTML.toLowerCase() > y.innerHTML.toLowerCase()) {
+              // If so, mark as a switch and break the loop:
               shouldSwitch = true;
               break;
             }
           }
-        } else {
-          // Regular text comparison
-          if (dir == "asc") {
-            if (x.innerHTML.toLowerCase() > y.innerHTML.toLowerCase()) {
+        } else if (dir == "desc") {
+          if (type == "int") {
+            if (parseInt(x.innerHTML.replace(/,/g, '')) < parseInt(y.innerHTML.replace(/,/g, ''))) {
+              // If so, mark as a switch and break the loop:
               shouldSwitch = true;
               break;
             }
-          } else if (dir == "desc") {
+          } else {
             if (x.innerHTML.toLowerCase() < y.innerHTML.toLowerCase()) {
+              // If so, mark as a switch and break the loop:
               shouldSwitch = true;
               break;
             }
           }
         }
       }
-      
       if (shouldSwitch) {
-        // If a switch has been marked, make the switch and mark that a switch has been done
+        /* If a switch has been marked, make the switch
+        and mark that a switch has been done: */
         rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
         switching = true;
-        // Each time a switch is done, increase the count by 1
+        // Each time a switch is done, increase this count by 1:
         switchcount++;
       } else {
-        // If no switching has been done AND the direction is "asc", set the direction to "desc" and run again
+        /* If no switching has been done AND the direction is "asc",
+        set the direction to "desc" and run the while loop again. */
         if (switchcount == 0 && dir == "asc") {
           dir = "desc";
           switching = true;
@@ -168,14 +207,18 @@
       }
     }
     
-    // Update the sort indicators in the headers
-    const headers = table.getElementsByTagName("th");
+    // Update all headers to remove any existing sort indicators
+    var headers = table.getElementsByTagName("TH");
     for (i = 0; i < headers.length; i++) {
-      if (i === n) {
-        headers[i].innerHTML = headers[i].innerHTML.replace(" ↕️", (dir === "asc" ? " ↑" : " ↓"));
-      } else {
-        headers[i].innerHTML = headers[i].innerHTML.replace(" ↑", " ↕️").replace(" ↓", " ↕️");
-      }
+      // Remove any existing sort indicators
+      headers[i].innerHTML = headers[i].innerHTML.replace(" ↑", "").replace(" ↓", "");
+    }
+    
+    // Add sort indicator to the clicked header
+    if (dir == "asc") {
+      element.innerHTML = element.innerHTML + " ↑";
+    } else {
+      element.innerHTML = element.innerHTML + " ↓";
     }
   }
 </script>

--- a/gui/templates/unprofitable_channels.html
+++ b/gui/templates/unprofitable_channels.html
@@ -49,12 +49,12 @@
                 {% else %}N/A{% endif %}</td>
             <td>{{ channel.rebalanced_out_sats|add:"0"|intcomma }}</td>
             <td>{% if channel.last_rebalance %}
-                {{ channel.last_rebalance.date|date:"M d, Y" }} ({{ channel.last_rebalance.amount|intcomma }} sats)
+                {{ channel.last_rebalance.date|date:"M d, Y" }} ({{ channel.last_rebalance.amount|floatformat:0|intcomma }} sats)
                 {% else %}N/A{% endif %}</td>
             <td {% if channel.profit < 0 %}style="color: red;"{% endif %}>{{ channel.profit|add:"0"|intcomma }}</td>
             <td>{{ channel.assisted_revenue|add:"0"|intcomma }}</td>
             <td>{% if channel.initiator %}Local{% else %}Remote{% endif %}</td>
-            <td>{{ channel.local_ratio }}%</td>
+            <td>{{ channel.local_ratio }}% ({{ channel.capacity_millions }}M)</td>
             <td {% if channel.stuck_index > 0.8 %}style="color: red;"{% elif channel.stuck_index > 0.4 %}style="color: orange;"{% else %}style="color: green;"{% endif %}>{{ channel.stuck_index }}</td>
             <td>
               <a style="display: inline-block;position:relative;width:25px;height:25px" href="#" data-value="{{ channel.chan_id }}" onclick="copyToClipboard('{{ channel.chan_id }}', this)">

--- a/gui/templates/unprofitable_channels.html
+++ b/gui/templates/unprofitable_channels.html
@@ -55,7 +55,7 @@
             <td>{{ channel.assisted_revenue|add:"0"|intcomma }}</td>
             <td>{% if channel.initiator %}Local{% else %}Remote{% endif %}</td>
             <td>{{ channel.local_ratio }}%</td>
-            <td {% if channel.stuck_index > 0.7 %}style="color: red;"{% elif channel.stuck_index > 0.4 %}style="color: orange;"{% else %}style="color: green;"{% endif %}>{{ channel.stuck_index }}</td>
+            <td {% if channel.stuck_index > 0.8 %}style="color: red;"{% elif channel.stuck_index > 0.4 %}style="color: orange;"{% else %}style="color: green;"{% endif %}>{{ channel.stuck_index }}</td>
             <td>
               <a style="display: inline-block;position:relative;width:25px;height:25px" href="#" data-value="{{ channel.chan_id }}" onclick="copyToClipboard('{{ channel.chan_id }}', this)">
                 <svg style="position:absolute;top:0;left:0;width:25px;height:25px" version="1.1" viewBox="0 0 16 16">

--- a/gui/templates/unprofitable_channels.html
+++ b/gui/templates/unprofitable_channels.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+{% block title %} {{ block.super }} - Unprofitable Channels{% endblock %}
+{% block content %}
+{% load humanize %}
+
+<div class="w3-container w3-padding-small">
+  <h2>Unprofitable Channels ({{ timeframe_name }})</h2>
+  
+  <!-- Timeframe Selection -->
+  <div class="w3-container w3-padding-small">
+    <form method="get" action="/unprofitable_channels/">
+      <label for="timeframe">Timeframe: </label>
+      <select id="timeframe" name="timeframe" onchange="this.form.submit()">
+        {% for key, option in timeframe_options.items %}
+          <option value="{{ key }}" {% if timeframe == key %}selected{% endif %}>{{ option.name }}</option>
+        {% endfor %}
+      </select>
+    </form>
+  </div>
+  
+  <!-- Channels Table -->
+  <div class="w3-container w3-padding-small" style="overflow-x: scroll">
+    <table class="w3-table-all w3-centered w3-hoverable">
+      <tr>
+        <th>Channel ID</th>
+        <th width=15%>Alias</th>
+        <th width=10%>Routed Out (sats)</th>
+        <th width=10%>Last Routing</th>
+        <th width=10%>Rebalanced Out (sats)</th>
+        <th width=10%>Last Rebalance</th>
+        <th width=8%>Profit</th>
+        <th width=8%>Assisted Revenue</th>
+        <th width=7%>Initiator</th>
+        <th width=10%>Actions</th>
+      </tr>
+      {% if channels %}
+        {% for channel in channels %}
+          <tr>
+            <td><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.chan_id }}</a></td>
+            <td>{% if channel.alias == '' %}---{% else %}{{ channel.alias }}{% endif %}</td>
+            <td>{{ channel.routed_out_sats|add:"0"|intcomma }}</td>
+            <td>{% if channel.last_routing %}{{ channel.last_routing|date:"M d, Y" }}{% else %}Never{% endif %}</td>
+            <td>{{ channel.rebalanced_out_sats|add:"0"|intcomma }}</td>
+            <td>{% if channel.last_rebalance %}{{ channel.last_rebalance|date:"M d, Y" }}{% else %}Never{% endif %}</td>
+            <td {% if channel.profit < 0 %}style="color: red;"{% endif %}>{{ channel.profit|add:"0"|intcomma }}</td>
+            <td>{{ channel.assisted_revenue|add:"0"|intcomma }}</td>
+            <td>{% if channel.initiator %}Local{% else %}Remote{% endif %}</td>
+            <td>
+              <a href="/closechannel/?={{ channel.chan_id }}" class="w3-button w3-small w3-red w3-round">Close</a>
+            </td>
+          </tr>
+        {% endfor %}
+      {% else %}
+        <tr>
+          <td colspan="10">No channel data available for the selected timeframe.</td>
+        </tr>
+      {% endif %}
+    </table>
+  </div>
+</div>
+
+<!-- Add a section explaining the metrics -->
+<div class="w3-container w3-padding-small">
+  <div class="w3-panel w3-pale-blue w3-leftbar w3-border-blue">
+    <h4>Understanding the Metrics:</h4>
+    <ul>
+      <li><strong>Routed Out:</strong> Total satoshis routed out through this channel</li>
+      <li><strong>Rebalanced Out:</strong> Total satoshis sent in rebalancing operations</li>
+      <li><strong>Profit:</strong> Fees earned from routing minus costs of rebalancing</li>
+      <li><strong>Assisted Revenue:</strong> Fees earned from forwards where this channel was the inbound channel</li>
+      <li><strong>Initiator:</strong> Whether you opened the channel (Local) or the peer opened it (Remote)</li>
+    </ul>
+    <p><em>Note: Channels with negative profit and low assisted revenue are good candidates for closure.</em></p>
+  </div>
+</div>
+{% endblock %}

--- a/gui/templates/unprofitable_channels.html
+++ b/gui/templates/unprofitable_channels.html
@@ -32,6 +32,8 @@
           <th onclick="sortTable(event.target, 6, 'int', 1)" width=8%>Profit</th>
           <th onclick="sortTable(event.target, 7, 'int', 1)" width=8%>Assisted Revenue</th>
           <th onclick="sortTable(event.target, 8, 'String', 1)" width=7%>Initiator</th>
+          <th onclick="sortTable(event.target, 9, 'int', 1)" width=7%>Local Ratio</th>
+          <th onclick="sortTable(event.target, 10, 'int', 1)" width=7%>Stuck Index</th>
           <th width=10%>Actions</th>
         </tr>
       </thead>
@@ -52,6 +54,8 @@
             <td {% if channel.profit < 0 %}style="color: red;"{% endif %}>{{ channel.profit|add:"0"|intcomma }}</td>
             <td>{{ channel.assisted_revenue|add:"0"|intcomma }}</td>
             <td>{% if channel.initiator %}Local{% else %}Remote{% endif %}</td>
+            <td>{{ channel.local_ratio }}%</td>
+            <td {% if channel.stuck_index > 0.7 %}style="color: red;"{% elif channel.stuck_index > 0.4 %}style="color: orange;"{% else %}style="color: green;"{% endif %}>{{ channel.stuck_index }}</td>
             <td>
               <a style="display: inline-block;position:relative;width:25px;height:25px" href="#" data-value="{{ channel.chan_id }}" onclick="copyToClipboard('{{ channel.chan_id }}', this)">
                 <svg style="position:absolute;top:0;left:0;width:25px;height:25px" version="1.1" viewBox="0 0 16 16">
@@ -67,7 +71,7 @@
         {% endfor %}
       {% else %}
         <tr>
-          <td colspan="10">No channel data available for the selected timeframe.</td>
+          <td colspan="12">No channel data available for the selected timeframe.</td>
         </tr>
       {% endif %}
       </tbody>
@@ -85,141 +89,148 @@
       <li><strong>Profit:</strong> Fees earned from routing minus costs of rebalancing</li>
       <li><strong>Assisted Revenue:</strong> Fees earned from forwards where this channel was the inbound channel</li>
       <li><strong>Initiator:</strong> Whether you opened the channel (Local) or the peer opened it (Remote)</li>
+      <li><strong>Local Ratio:</strong> Percentage of the channel's capacity that is on your side</li>
+      <li><strong>Stuck Index:</strong> Measure of how "stuck" a channel is (0 = active, 1 = inactive/stuck)</li>
     </ul>
-    <p><em>Note: Channels with negative profit and low assisted revenue are good candidates for closure.</em></p>
+    <p><em>Note: Channels with negative profit, low assisted revenue, and high stuck index are good candidates for closure.</em></p>
   </div>
 </div>
 
 <!-- JavaScript for sorting and copying -->
 <script>
-    function copyToClipboard(text, element) {
-      navigator.clipboard.writeText(text).then(function() {
-        // Show visual feedback
-        if (element) {
-          // If using the SVG icon
-          const originalIcon = element.querySelector('svg:first-child');
-          const checkmark = element.querySelector('.checkmark');
-          
-          // Hide original icon and show checkmark
-          originalIcon.style.visibility = 'hidden';
-          checkmark.style.visibility = 'visible';
-          
-          setTimeout(function() {
-            // Restore original icon and hide checkmark
-            originalIcon.style.visibility = 'visible';
-            checkmark.style.visibility = 'hidden';
-          }, 1500);
-        } else {
-          // If using the button
-          const button = event.target;
-          const originalText = button.textContent;
-          button.textContent = "Copied!";
-          button.style.backgroundColor = "#4CAF50";
-          
-          setTimeout(function() {
-            button.textContent = originalText;
-            button.style.backgroundColor = "";
-          }, 1500);
-        }
-      }, function() {
-        console.error('Failed to copy text to clipboard');
-      });
-      
-      // Prevent default link behavior
-      if (event && event.preventDefault) {
-        event.preventDefault();
+  function copyToClipboard(text, element) {
+    navigator.clipboard.writeText(text).then(function() {
+      // Show visual feedback
+      if (element) {
+        // If using the SVG icon
+        const originalIcon = element.querySelector('svg:first-child');
+        const checkmark = element.querySelector('.checkmark');
+        
+        // Hide original icon and show checkmark
+        originalIcon.style.visibility = 'hidden';
+        checkmark.style.visibility = 'visible';
+        
+        setTimeout(function() {
+          // Restore original icon and hide checkmark
+          originalIcon.style.visibility = 'visible';
+          checkmark.style.visibility = 'hidden';
+        }, 1500);
+      } else {
+        // If using the button
+        const button = event.target;
+        const originalText = button.textContent;
+        button.textContent = "Copied!";
+        button.style.backgroundColor = "#4CAF50";
+        
+        setTimeout(function() {
+          button.textContent = originalText;
+          button.style.backgroundColor = "";
+        }, 1500);
       }
-      return false;
+    }, function() {
+      console.error('Failed to copy text to clipboard');
+    });
+    
+    // Prevent default link behavior
+    if (event && event.preventDefault) {
+      event.preventDefault();
     }
+    return false;
+  }
 
   // Sorting function from channels.html
   function sortTable(element, n, type, asc, subElement = null) {
-    var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
-    table = document.getElementById("unprofitableChannelsTable");
-    switching = true;
-    // Set the sorting direction to ascending:
-    dir = asc ? "asc" : "desc";
-    /* Make a loop that will continue until
-    no switching has been done: */
-    while (switching) {
-      // Start by saying: no switching is done:
-      switching = false;
-      rows = table.rows;
-      /* Loop through all table rows (except the
-      first, which contains table headers): */
-      for (i = 1; i < (rows.length - 1); i++) {
-        // Start by saying there should be no switching:
-        shouldSwitch = false;
-        /* Get the two elements you want to compare,
-        one from current row and one from the next: */
-        x = rows[i].getElementsByTagName("TD")[n];
-        y = rows[i + 1].getElementsByTagName("TD")[n];
-        if (subElement != null) {
-          x = x.getElementsByTagName(subElement)[0];
-          y = y.getElementsByTagName(subElement)[0];
+  var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
+  table = document.getElementById("unprofitableChannelsTable");
+  switching = true;
+  // Set the sorting direction to ascending:
+  dir = asc ? "asc" : "desc";
+  
+  while (switching) {
+    switching = false;
+    rows = table.rows;
+    
+    for (i = 1; i < (rows.length - 1); i++) {
+      shouldSwitch = false;
+      x = rows[i].getElementsByTagName("TD")[n];
+      y = rows[i + 1].getElementsByTagName("TD")[n];
+      
+      if (subElement != null) {
+        x = x.getElementsByTagName(subElement)[0];
+        y = y.getElementsByTagName(subElement)[0];
+      }
+      
+      // Special handling for Stuck Index column (column 10)
+      if (n === 10) {
+        // Use parseFloat for decimal values
+        var xValue = parseFloat(x.innerHTML.replace(/,/g, '').replace(/%/g, ''));
+        var yValue = parseFloat(y.innerHTML.replace(/,/g, '').replace(/%/g, ''));
+        
+        if (dir == "asc") {
+          if (xValue > yValue) {
+            shouldSwitch = true;
+            break;
+          }
+        } else if (dir == "desc") {
+          if (xValue < yValue) {
+            shouldSwitch = true;
+            break;
+          }
         }
-        /* Check if the two rows should switch place,
-        based on the direction, asc or desc: */
+      } else {
+        // Original logic for other columns
         if (dir == "asc") {
           if (type == "int") {
-            if (parseInt(x.innerHTML.replace(/,/g, '')) > parseInt(y.innerHTML.replace(/,/g, ''))) {
-              // If so, mark as a switch and break the loop:
+            if (parseInt(x.innerHTML.replace(/,/g, '').replace(/%/g, '')) > parseInt(y.innerHTML.replace(/,/g, '').replace(/%/g, ''))) {
               shouldSwitch = true;
               break;
             }
           } else {
             if (x.innerHTML.toLowerCase() > y.innerHTML.toLowerCase()) {
-              // If so, mark as a switch and break the loop:
               shouldSwitch = true;
               break;
             }
           }
         } else if (dir == "desc") {
           if (type == "int") {
-            if (parseInt(x.innerHTML.replace(/,/g, '')) < parseInt(y.innerHTML.replace(/,/g, ''))) {
-              // If so, mark as a switch and break the loop:
+            if (parseInt(x.innerHTML.replace(/,/g, '').replace(/%/g, '')) < parseInt(y.innerHTML.replace(/,/g, '').replace(/%/g, ''))) {
               shouldSwitch = true;
               break;
             }
           } else {
             if (x.innerHTML.toLowerCase() < y.innerHTML.toLowerCase()) {
-              // If so, mark as a switch and break the loop:
               shouldSwitch = true;
               break;
             }
           }
         }
       }
-      if (shouldSwitch) {
-        /* If a switch has been marked, make the switch
-        and mark that a switch has been done: */
-        rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
+    }
+    
+    if (shouldSwitch) {
+      rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
+      switching = true;
+      switchcount++;
+    } else {
+      if (switchcount == 0 && dir == "asc") {
+        dir = "desc";
         switching = true;
-        // Each time a switch is done, increase this count by 1:
-        switchcount++;
-      } else {
-        /* If no switching has been done AND the direction is "asc",
-        set the direction to "desc" and run the while loop again. */
-        if (switchcount == 0 && dir == "asc") {
-          dir = "desc";
-          switching = true;
-        }
       }
     }
-    
-    // Update all headers to remove any existing sort indicators
-    var headers = table.getElementsByTagName("TH");
-    for (i = 0; i < headers.length; i++) {
-      // Remove any existing sort indicators
-      headers[i].innerHTML = headers[i].innerHTML.replace(" ↑", "").replace(" ↓", "");
-    }
-    
-    // Add sort indicator to the clicked header
-    if (dir == "asc") {
-      element.innerHTML = element.innerHTML + " ↑";
-    } else {
-      element.innerHTML = element.innerHTML + " ↓";
-    }
   }
+  
+  // Update all headers to remove any existing sort indicators
+  var headers = table.getElementsByTagName("TH");
+  for (i = 0; i < headers.length; i++) {
+    headers[i].innerHTML = headers[i].innerHTML.replace(" ↑", "").replace(" ↓", "");
+  }
+  
+  // Add sort indicator to the clicked header
+  if (dir == "asc") {
+    element.innerHTML = element.innerHTML + " ↑";
+  } else {
+    element.innerHTML = element.innerHTML + " ↓";
+  }
+}
 </script>
 {% endblock %}

--- a/gui/templates/unprofitable_channels.html
+++ b/gui/templates/unprofitable_channels.html
@@ -20,33 +20,40 @@
   
   <!-- Channels Table -->
   <div class="w3-container w3-padding-small" style="overflow-x: scroll">
-    <table class="w3-table-all w3-centered w3-hoverable">
-      <tr>
-        <th>Channel ID</th>
-        <th width=15%>Alias</th>
-        <th width=10%>Routed Out (sats)</th>
-        <th width=10%>Last Routing</th>
-        <th width=10%>Rebalanced Out (sats)</th>
-        <th width=10%>Last Rebalance</th>
-        <th width=8%>Profit</th>
-        <th width=8%>Assisted Revenue</th>
-        <th width=7%>Initiator</th>
-        <th width=10%>Actions</th>
-      </tr>
+    <table id="unprofitableChannelsTable" class="w3-table-all w3-centered w3-hoverable">
+      <thead>
+        <tr>
+          <th onclick="sortTable(0)">Channel ID ↕️</th>
+          <th onclick="sortTable(1)" width=15%>Alias ↕️</th>
+          <th onclick="sortTable(2, true)" width=10%>Routed Out (sats) ↕️</th>
+          <th onclick="sortTable(3)" width=10%>Last Routing ↕️</th>
+          <th onclick="sortTable(4, true)" width=10%>Rebalanced Out (sats) ↕️</th>
+          <th onclick="sortTable(5)" width=10%>Last Rebalance ↕️</th>
+          <th onclick="sortTable(6, true)" width=8%>Profit ↕️</th>
+          <th onclick="sortTable(7, true)" width=8%>Assisted Revenue ↕️</th>
+          <th onclick="sortTable(8)" width=7%>Initiator ↕️</th>
+          <th width=10%>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
       {% if channels %}
         {% for channel in channels %}
           <tr>
             <td><a href="/channel?={{ channel.chan_id }}" target="_blank">{{ channel.chan_id }}</a></td>
             <td>{% if channel.alias == '' %}---{% else %}{{ channel.alias }}{% endif %}</td>
             <td>{{ channel.routed_out_sats|add:"0"|intcomma }}</td>
-            <td>{% if channel.last_routing %}{{ channel.last_routing|date:"M d, Y" }}{% else %}Never{% endif %}</td>
+            <td>{% if channel.last_routing %}
+                {{ channel.last_routing.date|date:"M d, Y" }} ({{ channel.last_routing.amount|intcomma }} sats)
+                {% else %}N/A{% endif %}</td>
             <td>{{ channel.rebalanced_out_sats|add:"0"|intcomma }}</td>
-            <td>{% if channel.last_rebalance %}{{ channel.last_rebalance|date:"M d, Y" }}{% else %}Never{% endif %}</td>
+            <td>{% if channel.last_rebalance %}
+                {{ channel.last_rebalance.date|date:"M d, Y" }} ({{ channel.last_rebalance.amount|intcomma }} sats)
+                {% else %}N/A{% endif %}</td>
             <td {% if channel.profit < 0 %}style="color: red;"{% endif %}>{{ channel.profit|add:"0"|intcomma }}</td>
             <td>{{ channel.assisted_revenue|add:"0"|intcomma }}</td>
             <td>{% if channel.initiator %}Local{% else %}Remote{% endif %}</td>
             <td>
-              <a href="/closechannel/?={{ channel.chan_id }}" class="w3-button w3-small w3-red w3-round">Close</a>
+              <button onclick="copyToClipboard('{{ channel.chan_id }}')" class="w3-button w3-small w3-blue w3-round">Copy ID</button>
             </td>
           </tr>
         {% endfor %}
@@ -55,6 +62,7 @@
           <td colspan="10">No channel data available for the selected timeframe.</td>
         </tr>
       {% endif %}
+      </tbody>
     </table>
   </div>
 </div>
@@ -73,4 +81,102 @@
     <p><em>Note: Channels with negative profit and low assisted revenue are good candidates for closure.</em></p>
   </div>
 </div>
+
+<!-- JavaScript for sorting and copying -->
+<script>
+  function copyToClipboard(text) {
+    navigator.clipboard.writeText(text).then(function() {
+      // Show temporary success message
+      const button = event.target;
+      const originalText = button.textContent;
+      button.textContent = "Copied!";
+      button.style.backgroundColor = "#4CAF50";
+      
+      setTimeout(function() {
+        button.textContent = originalText;
+        button.style.backgroundColor = "";
+      }, 1500);
+    }, function() {
+      console.error('Failed to copy text to clipboard');
+    });
+  }
+
+  function sortTable(n, isNumeric = false) {
+    var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
+    table = document.getElementById("unprofitableChannelsTable");
+    switching = true;
+    // Set the sorting direction to ascending
+    dir = "asc";
+    
+    while (switching) {
+      switching = false;
+      rows = table.rows;
+      
+      // Skip header row and loop through rows
+      for (i = 1; i < (rows.length - 1); i++) {
+        shouldSwitch = false;
+        
+        // Get the two elements to compare
+        x = rows[i].getElementsByTagName("TD")[n];
+        y = rows[i + 1].getElementsByTagName("TD")[n];
+        
+        // Check if the two rows should switch places
+        if (isNumeric) {
+          // Parse numbers (remove commas and other non-numeric characters)
+          var xNum = parseInt(x.innerHTML.replace(/[^0-9.-]+/g, ""));
+          var yNum = parseInt(y.innerHTML.replace(/[^0-9.-]+/g, ""));
+          
+          if (dir == "asc") {
+            if (xNum > yNum) {
+              shouldSwitch = true;
+              break;
+            }
+          } else if (dir == "desc") {
+            if (xNum < yNum) {
+              shouldSwitch = true;
+              break;
+            }
+          }
+        } else {
+          // Regular text comparison
+          if (dir == "asc") {
+            if (x.innerHTML.toLowerCase() > y.innerHTML.toLowerCase()) {
+              shouldSwitch = true;
+              break;
+            }
+          } else if (dir == "desc") {
+            if (x.innerHTML.toLowerCase() < y.innerHTML.toLowerCase()) {
+              shouldSwitch = true;
+              break;
+            }
+          }
+        }
+      }
+      
+      if (shouldSwitch) {
+        // If a switch has been marked, make the switch and mark that a switch has been done
+        rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
+        switching = true;
+        // Each time a switch is done, increase the count by 1
+        switchcount++;
+      } else {
+        // If no switching has been done AND the direction is "asc", set the direction to "desc" and run again
+        if (switchcount == 0 && dir == "asc") {
+          dir = "desc";
+          switching = true;
+        }
+      }
+    }
+    
+    // Update the sort indicators in the headers
+    const headers = table.getElementsByTagName("th");
+    for (i = 0; i < headers.length; i++) {
+      if (i === n) {
+        headers[i].innerHTML = headers[i].innerHTML.replace(" ↕️", (dir === "asc" ? " ↑" : " ↓"));
+      } else {
+        headers[i].innerHTML = headers[i].innerHTML.replace(" ↑", " ↕️").replace(" ↓", " ↕️");
+      }
+    }
+  }
+</script>
 {% endblock %}

--- a/gui/urls.py
+++ b/gui/urls.py
@@ -60,6 +60,7 @@ urlpatterns = [
     path('remove_avoid/', views.remove_avoid, name='remove-avoid'),
     path('get_fees/', views.get_fees, name='get-fees'),
     path('opens/', views.opens, name='opens'),
+    path('unprofitable_channels/', views.unprofitable_channels, name='unprofitable-channels'),
     path('actions/', views.actions, name='actions'),
     path('fees/', views.fees, name='fees'),
     path('keysends/', views.keysends, name='keysends'),

--- a/gui/views.py
+++ b/gui/views.py
@@ -1181,7 +1181,6 @@ def unprofitable_channels(request):
                 metrics['last_rebalance_amount'] = payment.value if payment.value else 0
         
         # Calculate normalized metrics for each channel
-        # Calculate normalized metrics for each channel
         outbound_activities = []
         assisted_revenues = []
         fee_rates = []
@@ -1271,20 +1270,32 @@ def unprofitable_channels(request):
                 priority_score = 6.0
             # else: 7) No activity and no compensation (already set as default)
             
-            # NEW: Apply local liquidity adjustment
+            # TARGETED ADJUSTMENT: Apply assisted revenue bonus
+            # This gives a bonus for high assisted revenue without disrupting the main ranking
+            if assisted_revenue > high_assisted_threshold:
+                # Significant bonus for high assisted revenue
+                assisted_bonus = 1.5
+                priority_score = max(1.0, priority_score - assisted_bonus)
+            elif assisted_revenue > medium_assisted_threshold:
+                # Moderate bonus for medium assisted revenue
+                assisted_bonus = 0.75
+                priority_score = max(1.0, priority_score - assisted_bonus)
+            elif assisted_revenue > 0:
+                # Small bonus for any assisted revenue
+                assisted_bonus = 0.25
+                priority_score = max(1.0, priority_score - assisted_bonus)
+            
+            # Apply local liquidity adjustment
             # If local_ratio is low, reduce the penalty (improve the score)
-            # Define thresholds for local liquidity
             low_local_threshold = 0.2  # 20% or less is considered low local liquidity
             high_local_threshold = 0.8  # 80% or more is considered high local liquidity
             
             if local_ratio <= low_local_threshold:
                 # Significant improvement for channels with very low local liquidity
-                # Reduce penalty by up to 3 points (but not below 1)
                 local_liquidity_adjustment = 3.0 * (1 - (local_ratio / low_local_threshold))
                 priority_score = max(1.0, priority_score - local_liquidity_adjustment)
             elif local_ratio >= high_local_threshold:
                 # Slight penalty for channels with very high local liquidity
-                # Increase penalty by up to 0.5 points (but not above 7)
                 local_liquidity_adjustment = 0.5 * ((local_ratio - high_local_threshold) / (1 - high_local_threshold))
                 priority_score = min(7.0, priority_score + local_liquidity_adjustment)
             
@@ -1308,7 +1319,7 @@ def unprofitable_channels(request):
                 'local_ratio': local_ratio_pct,
                 'stuck_index': smart_stuck_index,
                 'local_fee_rate': local_fee_rate,
-                'priority_rank': round(priority_score, 1)  # Optional: add this to see the exact ranking with adjustment
+                'priority_rank': round(priority_score, 1)  # Shows the exact ranking with adjustment
             })
         
         # Sort by profit (ascending to show least profitable first)

--- a/gui/views.py
+++ b/gui/views.py
@@ -28,6 +28,19 @@ from requests import get
 from secrets import token_bytes
 from trade import create_trade_details
 import af
+import subprocess
+
+def get_remote_file_size():
+    try:
+        # Replace 'user', 'host', and '/path/to/channel.db' with your actual SSH user, host, and file path
+        command = "ssh admin@10.8.1.2 'du -b /home/admin/.lnd/data/graph/mainnet/channel.db  | cut -f1'"
+        result = subprocess.run(command, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        file_size_bytes = int(result.stdout.strip())
+        return round(file_size_bytes * 0.000000001, 3)  # Convert bytes to gigabytes
+    except Exception as e:
+        # Handle exceptions (e.g., SSH connection issues)
+        print(f"Error retrieving remote file size: {e}")
+        return 0
 
 def graph_links():
     if LocalSettings.objects.filter(key='GUI-GraphLinks').exists():
@@ -2620,7 +2633,8 @@ def node_info(request):
             waiting_for_close.append(pending_item)
     limbo_balance -= pending_closing_balance
     try:
-        db_size = round(path.getsize(path.expanduser(settings.LND_DATABASE_PATH))*0.000000001, 3)
+        # db_size = round(path.getsize(path.expanduser(settings.LND_DATABASE_PATH))*0.000000001, 3)
+        db_size = get_remote_file_size()
     except:
         db_size = 0
     return Response({

--- a/gui/views.py
+++ b/gui/views.py
@@ -1065,7 +1065,7 @@ def unprofitable_channels(request):
             '1': {'days': 1, 'name': '1 Day'},
             '7': {'days': 7, 'name': '7 Days'},
             '30': {'days': 30, 'name': '30 Days'},
-            '90': {'days': 90, 'name': '90 Days'}  # Added a 90-day option
+            '90': {'days': 90, 'name': '90 Days'}
         }
         
         selected_timeframe = timeframe_options.get(timeframe, timeframe_options['30'])
@@ -1075,124 +1075,105 @@ def unprofitable_channels(request):
         channels = Channels.objects.filter(is_active=True, is_open=True)
         channel_ids = [c.chan_id for c in channels]
         
-        # Batch query for out forwards - get statistics per channel
-        out_forwards_stats = {}
+        # Dictionary to store metrics for each channel
+        channel_metrics_dict = {chan_id: {
+            'routed_out_sats': 0,
+            'last_routing': None,
+            'last_routing_amount': 0,
+            'rebalanced_out_sats': 0,
+            'last_rebalance': None,
+            'last_rebalance_amount': 0,
+            'fee_revenue': 0,
+            'rebalance_fee_cost': 0,
+            'assisted_revenue': 0
+        } for chan_id in channel_ids}
+        
+        # 1. Get outbound forwarding stats (routing out)
         out_forwards = Forwards.objects.filter(
             chan_id_out__in=channel_ids,
             forward_date__gte=filter_date
-        ).values('chan_id_out').annotate(
-            routed_out_sats=Sum('amt_out_msat') / 1000,
-            total_fee=Sum('fee'),
-            last_forward=Max('forward_date')
         )
         
-        # Get the last forward details for each channel (for amount information)
-        last_forward_details = {}
-        for chan_id in channel_ids:
-            last_forward = Forwards.objects.filter(
-                chan_id_out=chan_id,
-                forward_date__gte=filter_date
-            ).order_by('-forward_date').first()
+        # Calculate total fees and amounts
+        for forward in out_forwards:
+            chan_id = forward.chan_id_out
+            metrics = channel_metrics_dict[chan_id]
             
-            if last_forward:
-                last_forward_details[chan_id] = {
-                    'date': last_forward.forward_date,
-                    'amount': int(last_forward.amt_out_msat / 1000) if last_forward.amt_out_msat else 0
-                }
+            # Update routed out sats
+            metrics['routed_out_sats'] += int(forward.amt_out_msat / 1000) if forward.amt_out_msat else 0
+            
+            # Update fee revenue
+            metrics['fee_revenue'] += forward.fee if forward.fee else 0
+            
+            # Track last routing event
+            if metrics['last_routing'] is None or forward.forward_date > metrics['last_routing']:
+                metrics['last_routing'] = forward.forward_date
+                metrics['last_routing_amount'] = int(forward.amt_out_msat / 1000) if forward.amt_out_msat else 0
         
-        for fwd in out_forwards:
-            chan_id = fwd['chan_id_out']
-            last_fwd_detail = last_forward_details.get(chan_id, None)
-            out_forwards_stats[chan_id] = {
-                'routed_out_sats': int(fwd['routed_out_sats'] or 0),
-                'fee': fwd['total_fee'] or 0,
-                'last_routing': last_fwd_detail
-            }
-        
-        # Batch query for in forwards (assisted revenue)
-        in_forwards_stats = {}
+        # 2. Get inbound forwarding stats (assisted revenue)
         in_forwards = Forwards.objects.filter(
             chan_id_in__in=channel_ids,
             forward_date__gte=filter_date
-        ).values('chan_id_in').annotate(
-            assisted_revenue=Sum('fee')
         )
         
-        for fwd in in_forwards:
-            in_forwards_stats[fwd['chan_id_in']] = {
-                'assisted_revenue': fwd['assisted_revenue'] or 0
-            }
+        for forward in in_forwards:
+            chan_id = forward.chan_id_in
+            channel_metrics_dict[chan_id]['assisted_revenue'] += forward.fee if forward.fee else 0
         
-        # Batch query for rebalance payments
-        rebalance_stats = {}
+        # 3. Get outbound rebalance data - using chan_out to match channels view
         rebalance_payments = Payments.objects.filter(
-            rebal_chan__in=channel_ids,
+            chan_out__in=channel_ids,  # This is the key change - using chan_out instead of rebal_chan
             creation_date__gte=filter_date,
-            status=2  # Successful payments
-        ).values('rebal_chan').annotate(
-            rebalanced_out_sats=Sum('value'),
-            rebalance_cost=Sum('fee'),
-            last_rebalance=Max('creation_date')
+            status=2,  # Successful payments
+            rebal_chan__isnull=False  # This identifies it as a rebalance
         )
         
-        # Get the last rebalance details for each channel (for amount information)
-        last_rebalance_details = {}
-        for chan_id in channel_ids:
-            last_rebalance = Payments.objects.filter(
-                rebal_chan=chan_id,
-                creation_date__gte=filter_date,
-                status=2
-            ).order_by('-creation_date').first()
+        for payment in rebalance_payments:
+            chan_id = payment.chan_out  # Using chan_out for outbound rebalances
+            metrics = channel_metrics_dict[chan_id]
             
-            if last_rebalance:
-                last_rebalance_details[chan_id] = {
-                    'date': last_rebalance.creation_date,
-                    'amount': last_rebalance.value or 0
-                }
+            # Update rebalanced out sats
+            metrics['rebalanced_out_sats'] += payment.value if payment.value else 0
+            
+            # Update rebalance fee cost
+            metrics['rebalance_fee_cost'] += payment.fee if payment.fee else 0
+            
+            # Track last rebalance event
+            if metrics['last_rebalance'] is None or payment.creation_date > metrics['last_rebalance']:
+                metrics['last_rebalance'] = payment.creation_date
+                metrics['last_rebalance_amount'] = payment.value if payment.value else 0
         
-        for reb in rebalance_payments:
-            chan_id = reb['rebal_chan']
-            last_reb_detail = last_rebalance_details.get(chan_id, None)
-            rebalance_stats[chan_id] = {
-                'rebalanced_out_sats': int(reb['rebalanced_out_sats'] or 0),
-                'rebalance_cost': reb['rebalance_cost'] or 0,
-                'last_rebalance': last_reb_detail
-            }
-        
-        # Combine all data and build the channel metrics list
+        # Build the final channel metrics list
         channel_metrics = []
         
         for channel in channels:
             chan_id = channel.chan_id
-            out_stats = out_forwards_stats.get(chan_id, {
-                'routed_out_sats': 0, 
-                'fee': 0, 
-                'last_routing': None
-            })
+            metrics = channel_metrics_dict[chan_id]
             
-            reb_stats = rebalance_stats.get(chan_id, {
-                'rebalanced_out_sats': 0, 
-                'rebalance_cost': 0, 
-                'last_rebalance': None
-            })
+            # Calculate profit (fee revenue - rebalance costs)
+            profit = metrics['fee_revenue'] - metrics['rebalance_fee_cost']
             
-            in_stats = in_forwards_stats.get(chan_id, {
-                'assisted_revenue': 0
-            })
+            # Format last routing and rebalance for display
+            last_routing = {
+                'date': metrics['last_routing'],
+                'amount': metrics['last_routing_amount']
+            } if metrics['last_routing'] else None
             
-            # Calculate profit
-            profit = out_stats['fee'] - reb_stats['rebalance_cost']
+            last_rebalance = {
+                'date': metrics['last_rebalance'],
+                'amount': metrics['last_rebalance_amount']
+            } if metrics['last_rebalance'] else None
             
             # Add metrics to the list
             channel_metrics.append({
                 'chan_id': chan_id,
-                'alias': channel.alias,
-                'routed_out_sats': out_stats['routed_out_sats'],
-                'last_routing': out_stats['last_routing'],
-                'rebalanced_out_sats': reb_stats['rebalanced_out_sats'],
-                'last_rebalance': reb_stats['last_rebalance'],
+                'alias': channel.alias or "---",
+                'routed_out_sats': metrics['routed_out_sats'],
+                'last_routing': last_routing,
+                'rebalanced_out_sats': metrics['rebalanced_out_sats'],
+                'last_rebalance': last_rebalance, 
                 'profit': profit,
-                'assisted_revenue': in_stats['assisted_revenue'],
+                'assisted_revenue': metrics['assisted_revenue'],
                 'initiator': channel.initiator,
                 'capacity': channel.capacity,
                 'local_balance': channel.local_balance,

--- a/gui/views.py
+++ b/gui/views.py
@@ -1064,7 +1064,8 @@ def unprofitable_channels(request):
         timeframe_options = {
             '1': {'days': 1, 'name': '1 Day'},
             '7': {'days': 7, 'name': '7 Days'},
-            '30': {'days': 30, 'name': '30 Days'}
+            '30': {'days': 30, 'name': '30 Days'},
+            '90': {'days': 90, 'name': '90 Days'}  # Added a 90-day option
         }
         
         selected_timeframe = timeframe_options.get(timeframe, timeframe_options['30'])
@@ -1085,11 +1086,27 @@ def unprofitable_channels(request):
             last_forward=Max('forward_date')
         )
         
+        # Get the last forward details for each channel (for amount information)
+        last_forward_details = {}
+        for chan_id in channel_ids:
+            last_forward = Forwards.objects.filter(
+                chan_id_out=chan_id,
+                forward_date__gte=filter_date
+            ).order_by('-forward_date').first()
+            
+            if last_forward:
+                last_forward_details[chan_id] = {
+                    'date': last_forward.forward_date,
+                    'amount': int(last_forward.amt_out_msat / 1000) if last_forward.amt_out_msat else 0
+                }
+        
         for fwd in out_forwards:
-            out_forwards_stats[fwd['chan_id_out']] = {
+            chan_id = fwd['chan_id_out']
+            last_fwd_detail = last_forward_details.get(chan_id, None)
+            out_forwards_stats[chan_id] = {
                 'routed_out_sats': int(fwd['routed_out_sats'] or 0),
                 'fee': fwd['total_fee'] or 0,
-                'last_routing': fwd['last_forward']
+                'last_routing': last_fwd_detail
             }
         
         # Batch query for in forwards (assisted revenue)
@@ -1118,11 +1135,28 @@ def unprofitable_channels(request):
             last_rebalance=Max('creation_date')
         )
         
+        # Get the last rebalance details for each channel (for amount information)
+        last_rebalance_details = {}
+        for chan_id in channel_ids:
+            last_rebalance = Payments.objects.filter(
+                rebal_chan=chan_id,
+                creation_date__gte=filter_date,
+                status=2
+            ).order_by('-creation_date').first()
+            
+            if last_rebalance:
+                last_rebalance_details[chan_id] = {
+                    'date': last_rebalance.creation_date,
+                    'amount': last_rebalance.value or 0
+                }
+        
         for reb in rebalance_payments:
-            rebalance_stats[reb['rebal_chan']] = {
+            chan_id = reb['rebal_chan']
+            last_reb_detail = last_rebalance_details.get(chan_id, None)
+            rebalance_stats[chan_id] = {
                 'rebalanced_out_sats': int(reb['rebalanced_out_sats'] or 0),
                 'rebalance_cost': reb['rebalance_cost'] or 0,
-                'last_rebalance': reb['last_rebalance']
+                'last_rebalance': last_reb_detail
             }
         
         # Combine all data and build the channel metrics list

--- a/gui/views.py
+++ b/gui/views.py
@@ -1146,6 +1146,20 @@ def unprofitable_channels(request):
         # Build the final channel metrics list
         channel_metrics = []
         
+        # Calculate total outbound activity for each channel (for stuck index)
+        outbound_activities = []
+        for channel in channels:
+            chan_id = channel.chan_id
+            metrics = channel_metrics_dict[chan_id]
+            total_outbound = metrics['routed_out_sats'] + metrics['rebalanced_out_sats']
+            outbound_activities.append(total_outbound)
+        
+        # Find min and max outbound activity for normalization
+        min_outbound = min(outbound_activities) if outbound_activities else 0
+        max_outbound = max(outbound_activities) if outbound_activities else 1
+        # Avoid division by zero
+        outbound_range = max(max_outbound - min_outbound, 1)
+        
         for channel in channels:
             chan_id = channel.chan_id
             metrics = channel_metrics_dict[chan_id]
@@ -1164,6 +1178,13 @@ def unprofitable_channels(request):
                 'amount': metrics['last_rebalance_amount']
             } if metrics['last_rebalance'] else None
             
+            # Calculate local ratio (percentage of capacity that is local balance)
+            local_ratio = round((channel.local_balance / channel.capacity) * 100, 2) if channel.capacity > 0 else 0
+            
+            # Calculate stuck index (normalized outbound activity)
+            total_outbound = metrics['routed_out_sats'] + metrics['rebalanced_out_sats']
+            stuck_index = round(1 - ((total_outbound - min_outbound) / outbound_range), 2) if outbound_range > 0 else 0
+            
             # Add metrics to the list
             channel_metrics.append({
                 'chan_id': chan_id,
@@ -1177,7 +1198,9 @@ def unprofitable_channels(request):
                 'initiator': channel.initiator,
                 'capacity': channel.capacity,
                 'local_balance': channel.local_balance,
-                'remote_balance': channel.remote_balance
+                'remote_balance': channel.remote_balance,
+                'local_ratio': local_ratio,
+                'stuck_index': stuck_index
             })
         
         # Sort by profit (ascending to show least profitable first)

--- a/gui/views.py
+++ b/gui/views.py
@@ -1057,6 +1057,129 @@ def opens(request):
         return redirect('home')
 
 @is_login_required(login_required(login_url='/lndg-admin/login/?next=/'), settings.LOGIN_REQUIRED)
+def unprofitable_channels(request):
+    if request.method == 'GET':
+        # Get the timeframe from the request, default to 30 days
+        timeframe = request.GET.get('timeframe', '30')
+        timeframe_options = {
+            '1': {'days': 1, 'name': '1 Day'},
+            '7': {'days': 7, 'name': '7 Days'},
+            '30': {'days': 30, 'name': '30 Days'}
+        }
+        
+        selected_timeframe = timeframe_options.get(timeframe, timeframe_options['30'])
+        filter_date = datetime.now() - timedelta(days=selected_timeframe['days'])
+        
+        # Get active channels in a single query
+        channels = Channels.objects.filter(is_active=True, is_open=True)
+        channel_ids = [c.chan_id for c in channels]
+        
+        # Batch query for out forwards - get statistics per channel
+        out_forwards_stats = {}
+        out_forwards = Forwards.objects.filter(
+            chan_id_out__in=channel_ids,
+            forward_date__gte=filter_date
+        ).values('chan_id_out').annotate(
+            routed_out_sats=Sum('amt_out_msat') / 1000,
+            total_fee=Sum('fee'),
+            last_forward=Max('forward_date')
+        )
+        
+        for fwd in out_forwards:
+            out_forwards_stats[fwd['chan_id_out']] = {
+                'routed_out_sats': int(fwd['routed_out_sats'] or 0),
+                'fee': fwd['total_fee'] or 0,
+                'last_routing': fwd['last_forward']
+            }
+        
+        # Batch query for in forwards (assisted revenue)
+        in_forwards_stats = {}
+        in_forwards = Forwards.objects.filter(
+            chan_id_in__in=channel_ids,
+            forward_date__gte=filter_date
+        ).values('chan_id_in').annotate(
+            assisted_revenue=Sum('fee')
+        )
+        
+        for fwd in in_forwards:
+            in_forwards_stats[fwd['chan_id_in']] = {
+                'assisted_revenue': fwd['assisted_revenue'] or 0
+            }
+        
+        # Batch query for rebalance payments
+        rebalance_stats = {}
+        rebalance_payments = Payments.objects.filter(
+            rebal_chan__in=channel_ids,
+            creation_date__gte=filter_date,
+            status=2  # Successful payments
+        ).values('rebal_chan').annotate(
+            rebalanced_out_sats=Sum('value'),
+            rebalance_cost=Sum('fee'),
+            last_rebalance=Max('creation_date')
+        )
+        
+        for reb in rebalance_payments:
+            rebalance_stats[reb['rebal_chan']] = {
+                'rebalanced_out_sats': int(reb['rebalanced_out_sats'] or 0),
+                'rebalance_cost': reb['rebalance_cost'] or 0,
+                'last_rebalance': reb['last_rebalance']
+            }
+        
+        # Combine all data and build the channel metrics list
+        channel_metrics = []
+        
+        for channel in channels:
+            chan_id = channel.chan_id
+            out_stats = out_forwards_stats.get(chan_id, {
+                'routed_out_sats': 0, 
+                'fee': 0, 
+                'last_routing': None
+            })
+            
+            reb_stats = rebalance_stats.get(chan_id, {
+                'rebalanced_out_sats': 0, 
+                'rebalance_cost': 0, 
+                'last_rebalance': None
+            })
+            
+            in_stats = in_forwards_stats.get(chan_id, {
+                'assisted_revenue': 0
+            })
+            
+            # Calculate profit
+            profit = out_stats['fee'] - reb_stats['rebalance_cost']
+            
+            # Add metrics to the list
+            channel_metrics.append({
+                'chan_id': chan_id,
+                'alias': channel.alias,
+                'routed_out_sats': out_stats['routed_out_sats'],
+                'last_routing': out_stats['last_routing'],
+                'rebalanced_out_sats': reb_stats['rebalanced_out_sats'],
+                'last_rebalance': reb_stats['last_rebalance'],
+                'profit': profit,
+                'assisted_revenue': in_stats['assisted_revenue'],
+                'initiator': channel.initiator,
+                'capacity': channel.capacity,
+                'local_balance': channel.local_balance,
+                'remote_balance': channel.remote_balance
+            })
+        
+        # Sort by profit (ascending to show least profitable first)
+        channel_metrics.sort(key=lambda x: x['profit'])
+        
+        context = {
+            'channels': channel_metrics,
+            'timeframe': timeframe,
+            'timeframe_name': selected_timeframe['name'],
+            'timeframe_options': timeframe_options
+        }
+        
+        return render(request, 'unprofitable_channels.html', context)
+    else:
+        return redirect('home')
+    
+@is_login_required(login_required(login_url='/lndg-admin/login/?next=/'), settings.LOGIN_REQUIRED)
 def actions(request):
     if request.method == 'GET':
         channels = Channels.objects.filter(is_active=True, is_open=True, private=False).annotate(outbound_percent=((Sum('local_balance')+Sum('pending_outbound'))*1000)/Sum('capacity'), inbound_percent=((Sum('remote_balance')+Sum('pending_inbound'))*1000)/Sum('capacity'))

--- a/gui/views.py
+++ b/gui/views.py
@@ -1180,23 +1180,38 @@ def unprofitable_channels(request):
                 metrics['last_rebalance'] = payment.creation_date
                 metrics['last_rebalance_amount'] = payment.value if payment.value else 0
         
+        # Calculate normalized metrics for each channel
+        # Calculate normalized metrics for each channel
+        outbound_activities = []
+        assisted_revenues = []
+        fee_rates = []
+
+        for chan_id, metrics in channel_metrics_dict.items():
+            outbound_activities.append(metrics['routed_out_sats'] + metrics['rebalanced_out_sats'])
+            assisted_revenues.append(metrics['assisted_revenue'])
+            
+            # Get channel object to access fee rate
+            channel_obj = next((c for c in channels if c.chan_id == chan_id), None)
+            if channel_obj:
+                fee_rate = getattr(channel_obj, 'local_fee_rate', 0) or 0
+                fee_rates.append(fee_rate)
+
+        # Find min/max values for normalization
+        max_outbound = max(outbound_activities) if outbound_activities else 1
+        max_assisted = max(assisted_revenues) if assisted_revenues else 1
+        max_fee_rate = max(fee_rates) if fee_rates else 1000
+
+        # Thresholds for high/medium/low classifications
+        high_activity_threshold = max_outbound * 0.7
+        medium_activity_threshold = max_outbound * 0.3
+        high_assisted_threshold = max_assisted * 0.7
+        medium_assisted_threshold = max_assisted * 0.3
+        high_fee_threshold = max(max_fee_rate, 1000) * 0.7
+        medium_fee_threshold = max(max_fee_rate, 1000) * 0.3
+
         # Build the final channel metrics list
         channel_metrics = []
-        
-        # Calculate total outbound activity for each channel (for stuck index)
-        outbound_activities = []
-        for channel in channels:
-            chan_id = channel.chan_id
-            metrics = channel_metrics_dict[chan_id]
-            total_outbound = metrics['routed_out_sats'] + metrics['rebalanced_out_sats']
-            outbound_activities.append(total_outbound)
-        
-        # Find min and max outbound activity for normalization
-        min_outbound = min(outbound_activities) if outbound_activities else 0
-        max_outbound = max(outbound_activities) if outbound_activities else 1
-        # Avoid division by zero
-        outbound_range = max(max_outbound - min_outbound, 1)
-        
+
         for channel in channels:
             chan_id = channel.chan_id
             metrics = channel_metrics_dict[chan_id]
@@ -1216,28 +1231,84 @@ def unprofitable_channels(request):
             } if metrics['last_rebalance'] else None
             
             # Calculate local ratio (percentage of capacity that is local balance)
-            local_ratio = round((channel.local_balance / channel.capacity) * 100, 2) if channel.capacity > 0 else 0
+            local_ratio = channel.local_balance / channel.capacity if channel.capacity > 0 else 0
+            local_ratio_pct = round(local_ratio * 100, 2)
             
-            # Calculate stuck index (normalized outbound activity)
-            total_outbound = metrics['routed_out_sats'] + metrics['rebalanced_out_sats']
-            stuck_index = round(1 - ((total_outbound - min_outbound) / outbound_range), 2) if outbound_range > 0 else 0
+            # Get activity metrics
+            routing_out = metrics['routed_out_sats']
+            rebalancing_out = metrics['rebalanced_out_sats']
+            total_outbound = routing_out + rebalancing_out
+            assisted_revenue = metrics['assisted_revenue']
+            
+            # Get fee rate
+            local_fee_rate = getattr(channel, 'local_fee_rate', 0) or 0
+            
+            # Calculate priority score based on activity and fees
+            # Lower score = better (less stuck), higher score = worse (more stuck)
+            # We'll use a score from 0-7 matching your priority list
+            
+            # Start with worst score
+            priority_score = 7.0
+            
+            # Check conditions from best to worst and assign appropriate score
+            if routing_out > high_activity_threshold and local_fee_rate > high_fee_threshold:
+                # 1) High routing out with high local_fee_rate
+                priority_score = 1.0
+            elif rebalancing_out > high_activity_threshold and assisted_revenue > high_assisted_threshold:
+                # 2) High rebalancing out with high assisted revenue
+                priority_score = 2.0
+            elif routing_out > medium_activity_threshold and local_fee_rate > medium_fee_threshold:
+                # 3) Medium routing out with medium local_fee_rate
+                priority_score = 3.0
+            elif rebalancing_out > medium_activity_threshold and assisted_revenue > medium_assisted_threshold:
+                # 4) Medium rebalancing out with medium assisted revenue
+                priority_score = 4.0
+            elif routing_out > 0 and local_fee_rate > 0:
+                # 5) Low routing out and low local_fee_rate
+                priority_score = 5.0
+            elif rebalancing_out > 0 and assisted_revenue > 0:
+                # 6) Low rebalancing out and low assisted revenue
+                priority_score = 6.0
+            # else: 7) No activity and no compensation (already set as default)
+            
+            # NEW: Apply local liquidity adjustment
+            # If local_ratio is low, reduce the penalty (improve the score)
+            # Define thresholds for local liquidity
+            low_local_threshold = 0.2  # 20% or less is considered low local liquidity
+            high_local_threshold = 0.8  # 80% or more is considered high local liquidity
+            
+            if local_ratio <= low_local_threshold:
+                # Significant improvement for channels with very low local liquidity
+                # Reduce penalty by up to 3 points (but not below 1)
+                local_liquidity_adjustment = 3.0 * (1 - (local_ratio / low_local_threshold))
+                priority_score = max(1.0, priority_score - local_liquidity_adjustment)
+            elif local_ratio >= high_local_threshold:
+                # Slight penalty for channels with very high local liquidity
+                # Increase penalty by up to 0.5 points (but not above 7)
+                local_liquidity_adjustment = 0.5 * ((local_ratio - high_local_threshold) / (1 - high_local_threshold))
+                priority_score = min(7.0, priority_score + local_liquidity_adjustment)
+            
+            # Normalize to 0-1 scale (divide by 7)
+            smart_stuck_index = round(priority_score / 7.0, 2)
             
             # Add metrics to the list
             channel_metrics.append({
                 'chan_id': chan_id,
                 'alias': channel.alias or "---",
-                'routed_out_sats': metrics['routed_out_sats'],
+                'routed_out_sats': routing_out,
                 'last_routing': last_routing,
-                'rebalanced_out_sats': metrics['rebalanced_out_sats'],
+                'rebalanced_out_sats': rebalancing_out,
                 'last_rebalance': last_rebalance, 
                 'profit': profit,
-                'assisted_revenue': metrics['assisted_revenue'],
+                'assisted_revenue': assisted_revenue,
                 'initiator': channel.initiator,
                 'capacity': channel.capacity,
                 'local_balance': channel.local_balance,
                 'remote_balance': channel.remote_balance,
-                'local_ratio': local_ratio,
-                'stuck_index': stuck_index
+                'local_ratio': local_ratio_pct,
+                'stuck_index': smart_stuck_index,
+                'local_fee_rate': local_fee_rate,
+                'priority_rank': round(priority_score, 1)  # Optional: add this to see the exact ranking with adjustment
             })
         
         # Sort by profit (ascending to show least profitable first)


### PR DESCRIPTION
# PR: Unprofitable Channels Feature

Added a new page to help spot channels that are costing us stuck liquidity, helpful for runners. Shows routing volume vs rebalancing costs over different timeframes (1D, 7D, 30D and 90D)

First had some performance issues that were causing timeouts - now it loads way faster adopting existing functions from the other pages

Added sorting, copy-to-clipboard, and some useful metrics to know what to look for
- last time rebalanced out and how much
- last time forwarded
- Local Ratio: % of channel capacity on our side
- Stuck Index: How inactive a channel is (higher = more stuck)

Color-coded the stuck index so it's easy to spot problem channels at a glance.

Now you can quickly see which channels are worth keeping and which ones you might want to close.

I had to rebase and may have included something from the af.py unintentionally. But it's late and I want to get it out, happy to review and adjust this next. Looking for some help and ideas what else to add as well