### PR TITLE
Add function to retrieve channel.db file size with LND remote suppor

### DIFF
--- a/gui/views.py
+++ b/gui/views.py
@@ -4,7 +4,6 @@ from django.db.models import Sum, IntegerField, Count, Max, F, Q, Case, When, Va
 from django.db.models.functions import Round, TruncDay, Coalesce
 from django.contrib.auth.decorators import login_required
 from django_filters import FilterSet, CharFilter, DateTimeFilter, NumberFilter
-from django.conf import settings
 from datetime import datetime, timedelta
 from rest_framework import viewsets
 from rest_framework.response import Response
@@ -24,7 +23,6 @@ from gui.lnd_deps import walletkit_pb2_grpc as walletstub
 from gui.lnd_deps.lnd_connect import lnd_connect
 from lndg import settings
 from os import path
-import os.path as path
 from pandas import DataFrame, merge
 from requests import get
 from secrets import token_bytes
@@ -2393,31 +2391,32 @@ def get_channeldb_file_size():
         if enabled:
             # Only import paramiko if enabled
             import paramiko
-            import stat
 
             # Create connection settings only if enabled AND they don't exist ---
-            host_setting = LocalSettings.objects.filter(key='RemoteFSHost').first()
-            if not host_setting:
+            host = LocalSettings.objects.filter(key='RemoteFSHost').first()
+            if not host:
                 LocalSettings.objects.create(key='RemoteFSHost', value='')
+                host = LocalSettings.objects.get(key='RemoteFSHost').value
 
-            user_setting = LocalSettings.objects.filter(key='RemoteFSUser').first()
-            if not user_setting:
+            user = LocalSettings.objects.filter(key='RemoteFSUser').first()
+            if not user:
                 LocalSettings.objects.create(key='RemoteFSUser', value='')
+                user = LocalSettings.objects.get(key='RemoteFSUser').value
 
-            port_setting = LocalSettings.objects.filter(key='RemoteFSPort').first()
-            if not port_setting:
+            port = LocalSettings.objects.filter(key='RemoteFSPort').first()
+            if not port:
                 LocalSettings.objects.create(key='RemoteFSPort', value='22')  # Default SSH port
+                port = LocalSettings.objects.get(key='RemoteFSPort').value
 
-            path_setting = LocalSettings.objects.filter(key='RemoteFSPath').first()
-            if not path_setting:
+            db_path = LocalSettings.objects.filter(key='RemoteFSPath').first()
+            if not db_path:
                 default_path = '/home/admin/.lnd/data/graph/mainnet/channel.db'
                 LocalSettings.objects.create(key='RemoteFSPath', value=default_path)
+                db_path = LocalSettings.objects.get(key='RemoteFSPath').value
 
             # Read the connection settings ---
-            host = LocalSettings.objects.get(key='RemoteFSHost').value
-            user = LocalSettings.objects.get(key='RemoteFSUser').value
-            port = int(LocalSettings.objects.get(key='RemoteFSPort').value)  # Ensure port is an integer
-            channel_db_path = LocalSettings.objects.get(key='RemoteFSPath').value if LocalSettings.objects.get(key='RemoteFSPath').value else settings.LND_DATABASE_PATH
+            port = int(port)  # Ensure port is an integer
+            channel_db_path = db_path.value if db_path.value else settings.LND_DATABASE_PATH # Use settings path if db path is blank
 
             # Check for required settings
             if not host or not user:

--- a/gui/views.py
+++ b/gui/views.py
@@ -2396,30 +2396,38 @@ def get_channeldb_file_size():
             host = LocalSettings.objects.filter(key='RemoteFSHost').first()
             if not host:
                 LocalSettings.objects.create(key='RemoteFSHost', value='')
-                host = LocalSettings.objects.get(key='RemoteFSHost').value
+                host_value = LocalSettings.objects.get(key='RemoteFSHost').value
+            else:
+                host_value = host.value
 
             user = LocalSettings.objects.filter(key='RemoteFSUser').first()
             if not user:
                 LocalSettings.objects.create(key='RemoteFSUser', value='')
-                user = LocalSettings.objects.get(key='RemoteFSUser').value
+                user_value = LocalSettings.objects.get(key='RemoteFSUser').value
+            else:
+                user_value = user.value
 
             port = LocalSettings.objects.filter(key='RemoteFSPort').first()
             if not port:
                 LocalSettings.objects.create(key='RemoteFSPort', value='22')  # Default SSH port
-                port = LocalSettings.objects.get(key='RemoteFSPort').value
+                port_value = LocalSettings.objects.get(key='RemoteFSPort').value
+            else:
+                port_value = port.value
 
             db_path = LocalSettings.objects.filter(key='RemoteFSPath').first()
             if not db_path:
                 default_path = '/home/admin/.lnd/data/graph/mainnet/channel.db'
                 LocalSettings.objects.create(key='RemoteFSPath', value=default_path)
-                db_path = LocalSettings.objects.get(key='RemoteFSPath').value
+                db_path_value = LocalSettings.objects.get(key='RemoteFSPath').value
+            else:
+                db_path_value = db_path.value
 
             # Read the connection settings ---
-            port = int(port)  # Ensure port is an integer
-            channel_db_path = db_path.value if db_path.value else settings.LND_DATABASE_PATH # Use settings path if db path is blank
+            port = int(port_value)  # Ensure port is an integer
+            channel_db_path = db_path_value if db_path_value else settings.LND_DATABASE_PATH # Use settings path if db path is blank
 
             # Check for required settings
-            if not host or not user:
+            if not host_value or not user_value:
                 print("Error: Remote file size enabled, but host or user is not set.")
                 return round(path.getsize(path.expanduser(settings.LND_DATABASE_PATH))*0.000000001, 3)
 
@@ -2430,7 +2438,7 @@ def get_channeldb_file_size():
                 ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())  # Automatically add host keys
 
                 # Connect to the remote host (eg 10.1.1.2, lnd, 22)
-                ssh.connect(hostname=host, username=user, port=port)
+                ssh.connect(hostname=host_value, username=user_value, port=port)
 
                 # Open an SFTP session
                 sftp = ssh.open_sftp()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests
 asyncio
 bech32
 cryptography
+paramiko


### PR DESCRIPTION
# Improved Remote Channel.db File Size Retrieval

Replaced the previous shell-based approach for retrieving the remote `channel.db` file size with a more robust and secure solution using the `paramiko` SSH library.

**Why this is better:**

*   **Security:** Avoids shell pipe vulnerabilities (e.g., command injection).
*   **Reliability:** Uses a dedicated SSH library (`paramiko`) for more stable and predictable connections.
*   **Efficiency:** Only imports `paramiko` if remote file size retrieval is enabled.
*   **Flexibility:**  Provides separate settings for host, user, port, and path.

## How to Enable Remote File Size Retrieval:

This feature is disabled by default. To enable it and retrieve the `channel.db` size from a remote LND node:

1.  **Enable the Feature:**
    *   Go to `https://<your-lndg-instance>/api/settings/RemoteFSEnabled/`
    *   Set the `value` to `1`.

2.  **Refresh the homepage to trigger the function**

3.  **Configure Connection Settings:**
    *   Go to `https://<your-lndg-instance>/api/settings/RemoteFSHost/`
    *   Set the `value` to the hostname or IP address of your remote LND node (e.g., `192.168.1.5` or `lnd.example.com`).

    *   Go to `https://<your-lndg-instance>/api/settings/RemoteFSUser/`
    *   Set the `value` to the SSH username for your remote LND node (e.g., `lnduser`).

    *   Go to `https://<your-lndg-instance>/api/settings/RemoteFSPort/`
    *   Set the `value` to the SSH port (usually `22`).  You likely don't need to change this.

    *   Go to `https://<your-lndg-instance>/api/settings/RemoteFSPath/`
    *   Set the `value` to the *full path* to the `channel.db` file on your *remote* LND node (e.g., `/home/lnduser/.lnd/data/graph/mainnet/channel.db`).

4. **Reload:** After setting these, reload any LNDg page.

That's it! LNDg will now use `paramiko` to securely retrieve the `channel.db` file size from your remote node. If the remote connection fails for any reason, LNDg will fall back to using the local `channel.db` file size.

@cryptosharks131 merged your fix but ran into errors later, so providing the fix in another clean PR