### PR TITLE
Update formatted number string to int parsing to fix different locales

### DIFF
--- a/gui/static/helpers.js
+++ b/gui/static/helpers.js
@@ -1,6 +1,6 @@
 //HELPER FUNCTIONS
 function byId(id){ return document.getElementById(id) }
-String.prototype.toInt = function(){ return parseInt(this.replace(/,/g,''))}
+String.prototype.toInt = function(){ return parseInt(this.replace(/\D/g,''))}
 String.prototype.toBool = function(if_false = 0){ return this && /^true$/i.test(this) ? 1 : if_false}
 Number.prototype.intcomma = function(){ return parseInt(this).toLocaleString() }
 HTMLElement.prototype.defaultCloneNode = HTMLElement.prototype.cloneNode

--- a/gui/static/helpers.js
+++ b/gui/static/helpers.js
@@ -1,6 +1,6 @@
 //HELPER FUNCTIONS
 function byId(id){ return document.getElementById(id) }
-String.prototype.toInt = function(){ return parseInt(this.replace(/\D/g,''))}
+String.prototype.toInt = function(){ return parseInt(this.replace(/[^\d-]/g,''))}
 String.prototype.toBool = function(if_false = 0){ return this && /^true$/i.test(this) ? 1 : if_false}
 Number.prototype.intcomma = function(){ return parseInt(this).toLocaleString() }
 HTMLElement.prototype.defaultCloneNode = HTMLElement.prototype.cloneNode


### PR DESCRIPTION
The helper function `intcomma()` uses `toLocaleString()`, but the reverse `toInt()` blindly assumes comma as a thousands separator and tries to remove just commas. In my locale, the thousand separator is space, so the functionality silently breaks. It parses "10 000" as 10. This fix addresses it by removing anything other than digits.