### PR TITLE
fix: resolve v1.11.0 log location bugs in baremetal and docker setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ services:
       - sh
       - -c
       # Customize network ('mainnet' or 'testnet') and RPC address/port if needed
-      - python initialize.py -net 'mainnet' -rpc '127.0.0.1:10009' -wn && python controller.py runserver 0.0.0.0:8889 > /var/log/lndg-controller.log 2>&1
+      - python initialize.py -net 'mainnet' -rpc '127.0.0.1:10009' -wn && python controller.py runserver 0.0.0.0:8889
     # Use host network mode for simplicity, adjust if needed
     network_mode: "host"
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,6 @@ services:
     command:
       - sh
       - -c
-      - python initialize.py -net 'mainnet' -rpc 'localhost:10009' -wn && python controller.py runserver 0.0.0.0:8000 > /app/data/lndg-controller.log 2>&1
+      - python initialize.py -net 'mainnet' -rpc 'localhost:10009' -wn && python controller.py runserver 0.0.0.0:8000
     ports:
       - 8889:8000

--- a/gui/views.py
+++ b/gui/views.py
@@ -235,7 +235,7 @@ def logs(request):
         try:
             count = request.GET.get('tail', 20)
             grep = request.GET.get('grep', None)
-            logfile = 'data/lndg-controller.log'
+            logfile = str(settings.BASE_DIR / 'data/lndg-controller.log')
             file_size = path.getsize(logfile)-2
             if file_size == 0:
                 logs = ['Logs are empty....']

--- a/gui/views.py
+++ b/gui/views.py
@@ -235,7 +235,7 @@ def logs(request):
         try:
             count = request.GET.get('tail', 20)
             grep = request.GET.get('grep', None)
-            logfile = str(settings.BASE_DIR / 'data/lndg-controller.log')
+            logfile = path.join(settings.BASE_DIR, 'data/lndg-controller.log')
             file_size = path.getsize(logfile)-2
             if file_size == 0:
                 logs = ['Logs are empty....']

--- a/initialize.py
+++ b/initialize.py
@@ -189,7 +189,7 @@ LOGGING = {
         'app-file': {
             'level': 'INFO',
             'class': 'logging.handlers.RotatingFileHandler',
-            'filename': 'data/lndg-controller.log',
+            'filename': os.path.join(BASE_DIR, 'data/lndg-controller.log'),
             'maxBytes': 25*(1024*1024),
             'backupCount': 5,
             'formatter': 'verbose',
@@ -197,7 +197,7 @@ LOGGING = {
         'web-file': {
             'level': 'INFO',
             'class': 'logging.handlers.RotatingFileHandler',
-            'filename': 'data/lndg-web.log',
+            'filename': os.path.join(BASE_DIR, 'data/lndg-web.log'),
             'maxBytes': 25*(1024*1024),
             'backupCount': 5,
             'formatter': 'verbose',

--- a/systemd.md
+++ b/systemd.md
@@ -13,9 +13,10 @@ Description=Backend Controller For Lndg
 Environment=PYTHONUNBUFFERED=1
 User=<run_as_user>
 Group=<run_as_user>
+WorkingDirectory=/home/<run_as_user>/lndg
 ExecStart=/home/<run_as_user>/lndg/.venv/bin/python /home/<run_as_user>/lndg/controller.py
-StandardOutput=append:/var/log/lndg-controller.log
-StandardError=append:/var/log/lndg-controller.log
+StandardOutput=journal
+StandardError=journal
 Restart=always
 RestartSec=60s
 [Install]

--- a/systemd.sh
+++ b/systemd.sh
@@ -34,9 +34,10 @@ Description=Run Backend Controller For Lndg
 Environment=PYTHONUNBUFFERED=1
 User=$INSTALL_USER
 Group=$INSTALL_USER
+WorkingDirectory=$LNDG_DIR
 ExecStart=$LNDG_DIR/.venv/bin/python $LNDG_DIR/controller.py
-StandardOutput=append:/var/log/lndg-controller.log
-StandardError=append:/var/log/lndg-controller.log
+StandardOutput=journal
+StandardError=journal
 Restart=always
 RestartSec=60s
 [Install]


### PR DESCRIPTION
# PR: Fix v1.11.0 log location bugs in baremetal and docker setups

## Summary of Changes
- This PR fixes the bugs introduced with the unified logging update in v1.11.0 where relative log paths failed under systemd, staled user configurations, and caused duplicated logs in Docker.

## Detailed Changes
- **initialize.py**: Configured settings template to construct absolute file paths using `BASE_DIR` for RotatingFileHandler logs (`lndg-controller.log` and `lndg-web.log`).
- **gui/views.py**: Resolved GUI `/logs` view logfile path absolutely using `settings.BASE_DIR`.
- **systemd.sh / systemd.md**: Added `WorkingDirectory` to systemd service template and redirected stdout/stderr to standard `journal` instead of `/var/log/lndg-controller.log`.
- **docker-compose.yaml / README.md**: Removed shell file redirection (`> /app/data/lndg-controller.log 2>&1`) to let Python's internal file rotating handler manage file logging cleanly.

Resolves #449

## Testing Strategy
- **Verification**: Verified using Django configuration system check (`manage.py check`) which passes cleanly. Live tested under systemd on VPS, validating that log files are created under user permissions in `data/` and updated in real-time.